### PR TITLE
feat: implement rally setup command

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
+import { setup } from '../lib/setup.js';
 
 const program = new Command();
 
@@ -7,5 +8,18 @@ program
   .name('rally')
   .description('Dispatch Squad teams to GitHub issues and PR reviews via git worktrees')
   .version('0.1.0');
+
+program
+  .command('setup')
+  .description('Initialize Squad team state and Rally directories')
+  .option('--dir <path>', 'Where to create external team state')
+  .action(async (options) => {
+    try {
+      await setup(options);
+    } catch (err) {
+      console.error(`✗ ${err.message}`);
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import ora from 'ora';
+import chalk from 'chalk';
+import { getConfigDir, writeConfig } from './config.js';
+
+/**
+ * Runs the rally setup command.
+ * Creates ~/.rally/team/ and ~/.rally/projects/, runs Squad init, writes config.yaml.
+ * Idempotent — skips existing directories with a message.
+ *
+ * @param {object} options
+ * @param {string} [options.dir] - Custom team directory path
+ * @param {Function} [options._exec] - Injectable exec function (for testing)
+ */
+export async function setup(options = {}) {
+  const configDir = getConfigDir();
+  const teamDir = options.dir || join(configDir, 'team');
+  const projectsDir = join(configDir, 'projects');
+  const exec = options._exec || execFileSync;
+
+  // Ensure base config directory exists
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+
+  // Create team directory
+  if (existsSync(teamDir)) {
+    console.log(`  Team directory already exists — skipping`);
+  } else {
+    mkdirSync(teamDir, { recursive: true });
+    console.log(chalk.green('✓') + ` Created team directory at ${teamDir}`);
+  }
+
+  // Create projects directory
+  if (existsSync(projectsDir)) {
+    console.log(`  Projects directory already exists — skipping`);
+  } else {
+    mkdirSync(projectsDir, { recursive: true });
+    console.log(chalk.green('✓') + ` Created projects directory at ${projectsDir}`);
+  }
+
+  // Run Squad init in team directory (skip if .squad/ already exists)
+  const squadDir = join(teamDir, '.squad');
+  if (existsSync(squadDir)) {
+    console.log(`  Squad already initialized — skipping`);
+  } else {
+    const spinner = ora('Initializing Squad...').start();
+    try {
+      exec('npx', ['github:bradygaster/squad'], {
+        cwd: teamDir,
+        stdio: 'pipe',
+      });
+      spinner.succeed('Initialized Squad in ' + teamDir);
+    } catch (err) {
+      spinner.fail('Squad initialization failed');
+      if (err.code === 'ENOENT') {
+        throw new Error('npx not found. Ensure Node.js and npm are installed and on your PATH.');
+      }
+      throw new Error(`Squad init failed: ${err.message}`);
+    }
+  }
+
+  // Write config.yaml
+  const config = {
+    teamDir,
+    projectsDir,
+    version: '0.1.0',
+  };
+  writeConfig(config);
+  console.log(chalk.green('✓') + ` Saved config to ${join(configDir, 'config.yaml')}`);
+}

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -1,0 +1,193 @@
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import yaml from 'js-yaml';
+import { setup } from '../lib/setup.js';
+
+describe('setup', () => {
+  let tempDir;
+  let originalEnv;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'rally-setup-test-'));
+    originalEnv = process.env.RALLY_HOME;
+    process.env.RALLY_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (originalEnv) {
+      process.env.RALLY_HOME = originalEnv;
+    } else {
+      delete process.env.RALLY_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // --- Acceptance Criteria: Creates Rally directories ---
+
+  test('creates team directory', async () => {
+    const teamDir = join(tempDir, 'team');
+    // Pre-create .squad so we skip npx
+    mkdirSync(teamDir, { recursive: true });
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+
+    await setup();
+
+    assert.ok(existsSync(teamDir), 'team directory should exist');
+  });
+
+  test('creates projects directory', async () => {
+    const teamDir = join(tempDir, 'team');
+    mkdirSync(teamDir, { recursive: true });
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+
+    await setup();
+
+    const projectsDir = join(tempDir, 'projects');
+    assert.ok(existsSync(projectsDir), 'projects directory should exist');
+  });
+
+  // --- Acceptance Criteria: Runs Squad init in team dir ---
+
+  test('runs Squad init when .squad/ does not exist', async () => {
+    let execCalled = false;
+    let execArgs = null;
+    const fakeExec = (cmd, args, opts) => {
+      execCalled = true;
+      execArgs = { cmd, args, cwd: opts.cwd };
+      // Simulate npx creating .squad/
+      mkdirSync(join(opts.cwd, '.squad'), { recursive: true });
+    };
+
+    await setup({ _exec: fakeExec });
+
+    assert.ok(execCalled, 'exec should have been called');
+    assert.strictEqual(execArgs.cmd, 'npx');
+    assert.deepStrictEqual(execArgs.args, ['github:bradygaster/squad']);
+    assert.strictEqual(execArgs.cwd, join(tempDir, 'team'));
+  });
+
+  test('skips Squad init when .squad/ already exists', async () => {
+    const teamDir = join(tempDir, 'team');
+    mkdirSync(teamDir, { recursive: true });
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+
+    let execCalled = false;
+    const fakeExec = () => { execCalled = true; };
+
+    await setup({ _exec: fakeExec });
+
+    assert.ok(!execCalled, 'exec should NOT have been called when .squad/ exists');
+  });
+
+  // --- Acceptance Criteria: Writes config.yaml ---
+
+  test('writes config.yaml with correct structure', async () => {
+    const teamDir = join(tempDir, 'team');
+    mkdirSync(teamDir, { recursive: true });
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+
+    await setup();
+
+    const configPath = join(tempDir, 'config.yaml');
+    assert.ok(existsSync(configPath), 'config.yaml should exist');
+
+    const config = yaml.load(readFileSync(configPath, 'utf8'));
+    assert.strictEqual(config.teamDir, teamDir);
+    assert.strictEqual(config.projectsDir, join(tempDir, 'projects'));
+    assert.strictEqual(config.version, '0.1.0');
+  });
+
+  test('writes config.yaml with custom --dir', async () => {
+    const customDir = join(tempDir, 'custom-team');
+    mkdirSync(customDir, { recursive: true });
+    mkdirSync(join(customDir, '.squad'), { recursive: true });
+
+    await setup({ dir: customDir });
+
+    const configPath = join(tempDir, 'config.yaml');
+    const config = yaml.load(readFileSync(configPath, 'utf8'));
+    assert.strictEqual(config.teamDir, customDir);
+  });
+
+  // --- Acceptance Criteria: Idempotent on re-run ---
+
+  test('idempotent: re-run skips existing directories and squad', async () => {
+    const teamDir = join(tempDir, 'team');
+    mkdirSync(teamDir, { recursive: true });
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+
+    // First run
+    await setup();
+
+    const configPath = join(tempDir, 'config.yaml');
+    const firstConfig = yaml.load(readFileSync(configPath, 'utf8'));
+
+    // Second run — should not throw
+    await setup();
+    const secondConfig = yaml.load(readFileSync(configPath, 'utf8'));
+
+    assert.deepStrictEqual(firstConfig, secondConfig);
+    assert.ok(existsSync(teamDir));
+    assert.ok(existsSync(join(tempDir, 'projects')));
+  });
+
+  test('idempotent: full re-run completes without error', async () => {
+    const teamDir = join(tempDir, 'team');
+    mkdirSync(teamDir, { recursive: true });
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+
+    await setup();
+    await assert.doesNotReject(() => setup());
+  });
+
+  // --- Error Cases ---
+
+  test('error: npx not found (ENOENT) throws descriptive error', async () => {
+    const fakeExec = () => {
+      const err = new Error('spawn npx ENOENT');
+      err.code = 'ENOENT';
+      throw err;
+    };
+
+    await assert.rejects(
+      () => setup({ _exec: fakeExec }),
+      (err) => {
+        assert.ok(err.message.includes('npx not found'), `Expected npx not found, got: ${err.message}`);
+        return true;
+      }
+    );
+  });
+
+  test('error: Squad init fails throws descriptive error', async () => {
+    const fakeExec = () => {
+      throw new Error('Command failed with exit code 1');
+    };
+
+    await assert.rejects(
+      () => setup({ _exec: fakeExec }),
+      (err) => {
+        assert.ok(err.message.includes('Squad init failed'), `Expected Squad init failed, got: ${err.message}`);
+        return true;
+      }
+    );
+  });
+
+  test('error: permission denied on directory creation', async () => {
+    const fakeExec = () => {};
+    // Use a file as a "directory" parent — mkdir inside a file always fails
+    const blocker = join(tempDir, 'blocker');
+    writeFileSync(blocker, 'not-a-dir');
+    const impossibleDir = join(blocker, 'subdir');
+
+    await assert.rejects(
+      () => setup({ dir: impossibleDir, _exec: fakeExec }),
+      (err) => {
+        assert.ok(err.message.length > 0, 'Should have an error message');
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
Closes #9

## Changes
- lib/setup.js: Rally directory creation, Squad init, config.yaml writing
- test/setup.test.js: Tests for all acceptance criteria
- bin/rally.js: Wire setup subcommand

## Acceptance Criteria
- [x] Creates Rally directories
- [x] Runs Squad init in team dir
- [x] Writes config.yaml
- [x] Idempotent on re-run