### PR TITLE
fix: skip anticipatory tests until implementations land

### DIFF
--- a/test/dispatch-context.test.js
+++ b/test/dispatch-context.test.js
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 // Module under test — will exist when #17 lands
 // import { writeIssueContext, writePrContext } from '../lib/dispatch-context.js';
 
-describe('dispatch-context', () => {
+describe('dispatch-context', { skip: 'awaiting #17 implementation' }, () => {
   let tempDir;
   let worktreePath;
 

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -12,7 +12,7 @@ import yaml from 'js-yaml';
 // Module under test — will exist when #15 lands
 // import { dispatchIssue } from '../lib/dispatch-issue.js';
 
-describe('dispatch issue', () => {
+describe('dispatch issue', { skip: 'awaiting #15 implementation' }, () => {
   let tempDir;
   let repoPath;
   let originalEnv;


### PR DESCRIPTION
Fixes CI failure from PR #37. The anticipatory test files for #15 and #17 were importing modules that don't exist yet, causing 35 test failures. Added `{ skip: 'awaiting implementation' }` to the top-level describe blocks so they're skipped until the implementations land.