### PR TITLE
feat: implement rally dispatch issue (#15)

### DIFF
--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -1,10 +1,10 @@
 import { execFileSync, spawn } from 'node:child_process';
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { getIssue } from './github.js';
-import { createWorktree, worktreeExists } from './worktree.js';
+import { createWorktree } from './worktree.js';
 import { createSymlink } from './symlink.js';
 import { addDispatch } from './active.js';
+import { readProjects } from './config.js';
 
 /**
  * Create a URL-safe slug from an issue title.
@@ -86,15 +86,17 @@ export function launchCopilot(worktreePath, prompt, opts = {}) {
  * Dispatch an issue: full workflow.
  *
  * Steps:
- *  1. Validate inputs
+ *  1. Validate inputs (including onboarding check)
  *  2. Fetch issue via gh CLI
  *  3. Create branch rally/{number}-{slug}
  *  4. Create worktree at .worktrees/rally-{number}/
  *  5. Symlink squad into worktree
  *  6. Write dispatch-context.md
- *  7. Add dispatch to active.yaml with status "planning"
- *  8. Launch Copilot CLI (gracefully skip if unavailable)
+ *  7. Launch Copilot CLI (gracefully skip if unavailable)
+ *  8. Add dispatch to active.yaml with status "planning" and session_id
  *  9. Return session info
+ *
+ * TODO: Wrap steps 4-6 in try-catch to clean up worktree on failure (#40 follow-up)
  *
  * @param {object} options
  * @param {number|string} options.issueNumber - GitHub issue number
@@ -124,6 +126,14 @@ export async function dispatchIssue(options = {}) {
   }
   if (!repoPath) {
     throw new Error('Repository path is required');
+  }
+
+  // Validate repo is onboarded
+  const repoName = repo.split('/')[1];
+  const projects = readProjects();
+  const projectList = (projects && projects.projects) || [];
+  if (!projectList.find((p) => p.name === repoName)) {
+    throw new Error(`Repository "${repo}" is not onboarded. Run: rally onboard ${repo}`);
   }
 
   const resolvedRepoPath = resolve(repoPath);
@@ -172,21 +182,7 @@ export async function dispatchIssue(options = {}) {
   }
   writeDispatchContext(squadDir, { repo, number, issue });
 
-  // 7. Add dispatch to active.yaml
-  const dispatchId = `${repo.split('/')[1]}-issue-${number}`;
-  const sessionId = null; // Will be updated after Copilot launch
-  const record = addDispatch({
-    id: dispatchId,
-    repo,
-    number,
-    type: 'issue',
-    branch,
-    worktreePath,
-    status: 'planning',
-    session_id: sessionId || 'pending',
-  });
-
-  // 8. Launch Copilot CLI
+  // 7. Launch Copilot CLI
   const prompt = `You are working on issue #${number}: ${issue.title}. Read .squad/dispatch-context.md for full context.`;
   let copilotResult = { sessionId: null, process: null };
   try {
@@ -195,15 +191,18 @@ export async function dispatchIssue(options = {}) {
     // Copilot CLI not available — gracefully skip
   }
 
-  // Update session_id if Copilot launched successfully
-  if (copilotResult.sessionId) {
-    try {
-      const { updateDispatchStatus } = await import('./active.js');
-      // We don't update status here, just note the session was captured
-    } catch {
-      // Non-critical — session ID capture is best-effort
-    }
-  }
+  // 8. Add dispatch to active.yaml (after Copilot launch so session_id is captured)
+  const dispatchId = `${repo.split('/')[1]}-issue-${number}`;
+  addDispatch({
+    id: dispatchId,
+    repo,
+    number,
+    type: 'issue',
+    branch,
+    worktreePath,
+    status: 'planning',
+    session_id: copilotResult.sessionId || 'pending',
+  });
 
   // 9. Return result
   return {

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -47,6 +47,10 @@ function setupRallyHome() {
   const rallyHome = process.env.RALLY_HOME;
   mkdirSync(rallyHome, { recursive: true });
   writeFileSync(join(rallyHome, 'config.yaml'), yaml.dump({ version: '0.1.0' }), 'utf8');
+  // Register test repo as onboarded
+  writeFileSync(join(rallyHome, 'projects.yaml'), yaml.dump({
+    projects: [{ name: 'repo', path: repoPath, team: 'shared', onboarded: new Date().toISOString() }],
+  }), 'utf8');
   return rallyHome;
 }
 
@@ -214,6 +218,22 @@ describe('dispatchIssue error paths', () => {
       }
     );
   });
+
+  test('throws when repo is not onboarded', async () => {
+    const rallyHome = process.env.RALLY_HOME;
+    mkdirSync(rallyHome, { recursive: true });
+    writeFileSync(join(rallyHome, 'config.yaml'), yaml.dump({ version: '0.1.0' }), 'utf8');
+    // No projects.yaml — repo is not onboarded
+
+    const exec = createExecWithIssue(makeIssue());
+    await assert.rejects(
+      () => dispatchIssue({ issueNumber: 1, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn }),
+      (err) => {
+        assert.ok(err.message.includes('not onboarded'));
+        return true;
+      }
+    );
+  });
 });
 
 // =====================================================
@@ -354,6 +374,11 @@ describe('dispatchIssue happy path', () => {
     });
 
     assert.strictEqual(result.sessionId, '98765');
+
+    // Verify session_id is persisted to active.yaml
+    const activePath = join(process.env.RALLY_HOME, 'active.yaml');
+    const active = yaml.load(readFileSync(activePath, 'utf8'));
+    assert.strictEqual(active.dispatches[0].session_id, '98765');
   });
 
   test('gracefully handles Copilot CLI not available', async () => {


### PR DESCRIPTION
Closes #15

## Changes
- **lib/dispatch-issue.js**: Full dispatch workflow — `dispatchIssue()` orchestrates: fetch issue via gh CLI, create `rally/{number}-{slug}` branch, create worktree at `.worktrees/rally-{number}/`, symlink squad, write dispatch-context.md, log to active.yaml with status `planning`, launch Copilot CLI. Includes `slugify()`, `writeDispatchContext()` (inline placeholder for #17), and `launchCopilot()` with graceful degradation.
- **test/dispatch-issue.test.js**: 18 tests replacing anticipatory stubs. Uses real git repos in temp directories. Covers error paths (missing args, issue not found, worktree exists), slugify edge cases, context file writing, and full happy-path workflow.

## Acceptance Criteria
- [x] Full workflow: fetch → branch → worktree → symlink → context → launch
- [x] Copilot CLI launched with appropriate prompt (gracefully skips if unavailable)
- [x] Session ID captured (from spawn PID)
- [x] Active registry updated (active.yaml with status `planning`)
- [x] Error cases: issue not found, worktree already exists, missing arguments
- [x] Branch naming: `rally/{number}-{slug}`
- [x] Worktree path: `.worktrees/rally-{number}/`
- [x] Inline `writeDispatchContext()` as placeholder for #17
- [x] Dependency injection (`_exec`, `_spawn`) for testability

## Test Results
All 18 new tests pass (176 total across full suite, 0 failures).