### PR TITLE
perf: extract dashboard-data.js to avoid ink import in non-TTY paths

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -58,11 +58,11 @@ const dashboard = program
   .action(async (opts) => {
     try {
       if (opts.json) {
-        const { getDashboardData } = await import('../lib/ui/Dashboard.js');
+        const { getDashboardData } = await import('../lib/ui/dashboard-data.js');
         const data = getDashboardData({ project: opts.project });
         console.log(JSON.stringify(data, null, 2));
       } else if (!process.stdout.isTTY) {
-        const { renderPlainDashboard } = await import('../lib/ui/Dashboard.js');
+        const { renderPlainDashboard } = await import('../lib/ui/dashboard-data.js');
         console.log(renderPlainDashboard({ project: opts.project }));
       } else {
         const React = await import('react');

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -1,55 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
-import { existsSync } from 'node:fs';
-import { getActiveDispatches } from '../active.js';
 import DispatchTable from './components/DispatchTable.jsx';
-import { formatAge } from './components/DispatchTable.jsx';
+import { computeSummary, getDashboardData, renderPlainDashboard } from './dashboard-data.js';
 
-/**
- * Check worktree health by verifying paths exist on disk.
- */
-function checkWorktreeHealth(dispatches) {
-  return dispatches.map(d => ({
-    ...d,
-    healthy: d.worktreePath ? existsSync(d.worktreePath) : false,
-  }));
-}
-
-/**
- * Compute summary counts from dispatches.
- */
-export function computeSummary(dispatches) {
-  let active = 0;
-  let done = 0;
-  let blocked = 0;
-
-  for (const d of dispatches) {
-    if (d.status === 'done' || d.status === 'cleaned') {
-      done++;
-    } else if (!d.healthy) {
-      blocked++;
-    } else {
-      active++;
-    }
-  }
-
-  return { active, done, blocked };
-}
-
-/**
- * Load and process dashboard data.
- */
-export function getDashboardData({ project } = {}) {
-  const raw = getActiveDispatches();
-  let dispatches = checkWorktreeHealth(raw);
-
-  if (project) {
-    dispatches = dispatches.filter(d => d.repo && d.repo.includes(project));
-  }
-
-  const summary = computeSummary(dispatches);
-  return { dispatches, summary };
-}
+export { computeSummary, getDashboardData, renderPlainDashboard };
 
 /**
  * Summary line component.
@@ -66,50 +20,6 @@ function SummaryLine({ summary }) {
       </Text>
     </Box>
   );
-}
-
-/**
- * Render a plain text dashboard (no ANSI escape codes) for non-TTY environments.
- */
-export function renderPlainDashboard({ project } = {}) {
-  const { dispatches, summary } = getDashboardData({ project });
-  
-  const lines = [];
-  lines.push('Rally Dashboard');
-  lines.push('');
-  
-  // Table headers
-  const colWidths = { project: 20, issueRef: 12, branch: 28, status: 16, age: 6 };
-  const header = [
-    'Project'.padEnd(colWidths.project),
-    'Issue/PR'.padEnd(colWidths.issueRef),
-    'Branch'.padEnd(colWidths.branch),
-    'Status'.padEnd(colWidths.status),
-    'Age'.padEnd(colWidths.age),
-  ].join(' ');
-  lines.push(header);
-  
-  if (dispatches.length === 0) {
-    lines.push('No active dispatches');
-  } else {
-    for (const d of dispatches) {
-      const issueRef = d.type === 'pr' ? `PR #${d.number}` : `Issue #${d.number}`;
-      const age = formatAge(d.created ?? d.created_at);
-      const row = [
-        (d.repo ?? '').padEnd(colWidths.project),
-        issueRef.padEnd(colWidths.issueRef),
-        (d.branch ?? '').padEnd(colWidths.branch),
-        (d.status ?? '').padEnd(colWidths.status),
-        age.padEnd(colWidths.age),
-      ].join(' ');
-      lines.push(row);
-    }
-  }
-  
-  lines.push('');
-  lines.push(`${summary.active} active · ${summary.done} done · ${summary.blocked} blocked`);
-  
-  return lines.join('\n');
 }
 
 /**

--- a/lib/ui/components/DispatchTable.jsx
+++ b/lib/ui/components/DispatchTable.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import { formatAge } from '../dashboard-data.js';
 
 const STATUS_ICONS = {
   planning: '🔵',
@@ -8,23 +9,6 @@ const STATUS_ICONS = {
   done: '✅',
   cleaned: '⚪',
 };
-
-/**
- * Compute a human-readable age string from an ISO timestamp.
- */
-export function formatAge(createdAt) {
-  if (!createdAt) return '—';
-  const ts = new Date(createdAt).getTime();
-  if (Number.isNaN(ts)) return '—';
-  const ms = Date.now() - ts;
-  if (ms < 0) return '0m';
-  const minutes = Math.floor(ms / 60000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
-}
 
 function formatIssueRef(dispatch) {
   const prefix = dispatch.type === 'pr' ? 'PR' : 'Issue';

--- a/lib/ui/dashboard-data.js
+++ b/lib/ui/dashboard-data.js
@@ -1,0 +1,108 @@
+import { existsSync } from 'node:fs';
+import { getActiveDispatches } from '../active.js';
+
+/**
+ * Format a timestamp into a human-readable age string.
+ */
+export function formatAge(createdAt) {
+  if (!createdAt) return '—';
+  const ts = new Date(createdAt).getTime();
+  if (Number.isNaN(ts)) return '—';
+  const ms = Date.now() - ts;
+  if (ms < 0) return '0m';
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+/**
+ * Check worktree health by verifying paths exist on disk.
+ */
+export function checkWorktreeHealth(dispatches) {
+  return dispatches.map(d => ({
+    ...d,
+    healthy: d.worktreePath ? existsSync(d.worktreePath) : false,
+  }));
+}
+
+/**
+ * Compute summary counts from dispatches.
+ */
+export function computeSummary(dispatches) {
+  let active = 0;
+  let done = 0;
+  let blocked = 0;
+
+  for (const d of dispatches) {
+    if (d.status === 'done' || d.status === 'cleaned') {
+      done++;
+    } else if (!d.healthy) {
+      blocked++;
+    } else {
+      active++;
+    }
+  }
+
+  return { active, done, blocked };
+}
+
+/**
+ * Load and process dashboard data.
+ */
+export function getDashboardData({ project } = {}) {
+  const raw = getActiveDispatches();
+  let dispatches = checkWorktreeHealth(raw);
+
+  if (project) {
+    dispatches = dispatches.filter(d => d.repo && d.repo.includes(project));
+  }
+
+  const summary = computeSummary(dispatches);
+  return { dispatches, summary };
+}
+
+/**
+ * Render a plain text dashboard (no ANSI escape codes) for non-TTY environments.
+ */
+export function renderPlainDashboard({ project } = {}) {
+  const { dispatches, summary } = getDashboardData({ project });
+
+  const lines = [];
+  lines.push('Rally Dashboard');
+  lines.push('');
+
+  const colWidths = { project: 20, issueRef: 12, branch: 28, status: 16, age: 6 };
+  const header = [
+    'Project'.padEnd(colWidths.project),
+    'Issue/PR'.padEnd(colWidths.issueRef),
+    'Branch'.padEnd(colWidths.branch),
+    'Status'.padEnd(colWidths.status),
+    'Age'.padEnd(colWidths.age),
+  ].join(' ');
+  lines.push(header);
+
+  if (dispatches.length === 0) {
+    lines.push('No active dispatches');
+  } else {
+    for (const d of dispatches) {
+      const issueRef = d.type === 'pr' ? `PR #${d.number}` : `Issue #${d.number}`;
+      const age = formatAge(d.created ?? d.created_at);
+      const row = [
+        (d.repo ?? '').padEnd(colWidths.project),
+        issueRef.padEnd(colWidths.issueRef),
+        (d.branch ?? '').padEnd(colWidths.branch),
+        (d.status ?? '').padEnd(colWidths.status),
+        age.padEnd(colWidths.age),
+      ].join(' ');
+      lines.push(row);
+    }
+  }
+
+  lines.push('');
+  lines.push(`${summary.active} active · ${summary.done} done · ${summary.blocked} blocked`);
+
+  return lines.join('\n');
+}

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,4 +1,5 @@
 export { default as StatusMessage } from './components/StatusMessage.js';
 export { default as DispatchBox } from './components/DispatchBox.js';
-export { default as DispatchTable, STATUS_ICONS, formatAge } from './components/DispatchTable.js';
-export { default as Dashboard, getDashboardData, computeSummary, renderPlainDashboard } from './Dashboard.js';
+export { default as DispatchTable, STATUS_ICONS } from './components/DispatchTable.js';
+export { formatAge, getDashboardData, computeSummary, renderPlainDashboard } from './dashboard-data.js';
+export { default as Dashboard } from './Dashboard.js';

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -12,7 +12,7 @@ import yaml from 'js-yaml';
 import { dispatchIssue } from '../lib/dispatch-issue.js';
 import { dispatchPr } from '../lib/dispatch-pr.js';
 import { getActiveDispatches, removeDispatch } from '../lib/active.js';
-import { getDashboardData, computeSummary, renderPlainDashboard } from '../lib/ui/Dashboard.js';
+import { getDashboardData, computeSummary, renderPlainDashboard } from '../lib/ui/dashboard-data.js';
 
 // =====================================================
 // Helpers

--- a/test/non-tty.test.js
+++ b/test/non-tty.test.js
@@ -4,7 +4,7 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import yaml from 'js-yaml';
-import { renderPlainDashboard } from '../../lib/ui/Dashboard.js';
+import { renderPlainDashboard } from '../lib/ui/dashboard-data.js';
 
 let TEST_DIR;
 let WORKTREE_DIR;

--- a/test/ui/DispatchTable.test.js
+++ b/test/ui/DispatchTable.test.js
@@ -2,7 +2,8 @@ import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
 import { render } from 'ink-testing-library';
-import { DispatchTable, STATUS_ICONS, formatAge } from '../../lib/ui/index.js';
+import DispatchTable, { STATUS_ICONS } from '../../lib/ui/components/DispatchTable.js';
+import { formatAge } from '../../lib/ui/dashboard-data.js';
 
 let lastCleanup;
 afterEach(() => { if (lastCleanup) lastCleanup(); });

--- a/test/ui/StatusMessage.test.js
+++ b/test/ui/StatusMessage.test.js
@@ -2,7 +2,7 @@ import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
 import { render, cleanup } from 'ink-testing-library';
-import { StatusMessage } from '../../lib/ui/index.js';
+import StatusMessage from '../../lib/ui/components/StatusMessage.js';
 
 afterEach(() => { cleanup(); });
 


### PR DESCRIPTION
## Summary

Extracts pure data functions into `lib/ui/dashboard-data.js` to avoid the slow `ink → es-toolkit/compat` transitive import (~30s per process on some environments) for code paths that don't need Ink rendering.

### Changes

- **New `lib/ui/dashboard-data.js`** — Contains `formatAge`, `computeSummary`, `getDashboardData`, `renderPlainDashboard` (no ink dependency)
- **`Dashboard.jsx`** — Imports data functions from `dashboard-data.js` instead of defining inline
- **`DispatchTable.jsx`** — Imports `formatAge` from `dashboard-data.js` (single source of truth)
- **`bin/rally.js`** — JSON and non-TTY dashboard modes import from `dashboard-data.js` (fast path)
- **`test/non-tty.test.js`** — Moved from `test/ui/` since it doesn't need ink; now runs in 0.6s instead of 29s
- **`test/ui/StatusMessage.test.js`** — Imports component directly instead of through `index.js`
- **`test/ui/DispatchTable.test.js`** — Imports component directly
- **`test/integration.test.js`** — Imports from `dashboard-data.js`

### Impact

- CLI `rally dashboard --json` and non-TTY mode: no longer load ink at all
- Test suite: ~1.5 min faster locally (non-tty tests avoid 30s ink import)
- CI: already fast (~5s), no regression