### PR TITLE
feat: wire dispatch issue and dispatch pr CLI subcommands

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -89,4 +89,56 @@ dashboard
     }
   });
 
+const dispatch = program
+  .command('dispatch')
+  .description('Dispatch Squad to a GitHub issue or PR');
+
+dispatch
+  .command('issue')
+  .description('Dispatch Squad to a GitHub issue')
+  .argument('<number>', 'GitHub issue number')
+  .option('--repo <owner/repo>', 'Target repository (owner/repo)')
+  .option('--repo-path <path>', 'Path to local repo clone')
+  .option('--team-dir <path>', 'Path to custom squad directory')
+  .action(async (number, opts) => {
+    try {
+      const { resolveRepo } = await import('../lib/dispatch.js');
+      const { dispatchIssue } = await import('../lib/dispatch-issue.js');
+      const resolved = resolveRepo({ repo: opts.repo });
+      const result = await dispatchIssue({
+        issueNumber: number,
+        repo: resolved.fullName,
+        repoPath: opts.repoPath || resolved.project.path,
+        teamDir: opts.teamDir,
+      });
+      console.log(`Dispatched issue #${number} → ${result.worktreePath}`);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+dispatch
+  .command('pr')
+  .description('Dispatch Squad to a GitHub PR review')
+  .argument('<number>', 'GitHub PR number')
+  .option('--repo <owner/repo>', 'Target repository (owner/repo)')
+  .option('--repo-path <path>', 'Path to local repo clone')
+  .option('--team-dir <path>', 'Path to custom squad directory')
+  .action(async (number, opts) => {
+    try {
+      const { resolveRepo } = await import('../lib/dispatch.js');
+      const { dispatchPr } = await import('../lib/dispatch-pr.js');
+      const resolved = resolveRepo({ repo: opts.repo });
+      const result = await dispatchPr({
+        prNumber: number,
+        repo: resolved.fullName,
+        repoPath: opts.repoPath || resolved.project.path,
+        teamDir: opts.teamDir,
+      });
+      console.log(`Dispatched PR #${number} → ${result.worktreePath}`);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
 program.parse();


### PR DESCRIPTION
## What

Wires the existing `dispatchIssue()` and `dispatchPr()` lib functions as CLI subcommands in `bin/rally.js`.

### Commands added

- `rally dispatch issue <number>` — dispatches Squad to a GitHub issue
- `rally dispatch pr <number>` — dispatches Squad to a GitHub PR review

### Options (both subcommands)

- `--repo <owner/repo>` — target repository
- `--repo-path <path>` — path to local repo clone
- `--team-dir <path>` — path to custom squad directory

### Pattern

Follows the exact same structure as `dashboard clean`:
- Dynamic imports for the dispatch modules
- `resolveRepo()` for repo inference (flag → cwd → single-project fallback)
- `handleError(err)` in catch blocks
- Options passed through to the lib functions

### Testing

All 309 tests pass (277 unit + 32 UI). No new tests needed — this is pure command wiring.

Closes #56