### PR TITLE
fix: tool validation, dynamic version, worktree detection, remove writeActive

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -1,16 +1,23 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 import { setup } from '../lib/setup.js';
 import { onboard } from '../lib/onboard.js';
 import { getStatus, formatStatus } from '../lib/status.js';
 import { handleError } from '../lib/errors.js';
+import { assertTools } from '../lib/tools.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
 
 const program = new Command();
 
 program
   .name('rally')
   .description('Dispatch Squad teams to GitHub issues and PR reviews via git worktrees')
-  .version('0.1.0');
+  .version(pkg.version);
 
 program
   .command('setup')
@@ -29,6 +36,7 @@ program
   .description('Onboard a repo to Rally (local path, GitHub URL, or owner/repo)')
   .argument('[path]', 'Path, GitHub URL, or owner/repo (defaults to current directory)')
   .option('--team <name>', 'Use a named team (skips interactive prompt)')
+  .hook('preAction', () => assertTools())
   .action(async (pathArg, opts) => {
     try {
       await onboard({ path: pathArg, team: opts.team });
@@ -91,7 +99,8 @@ dashboard
 
 const dispatch = program
   .command('dispatch')
-  .description('Dispatch Squad to a GitHub issue or PR');
+  .description('Dispatch Squad to a GitHub issue or PR')
+  .hook('preAction', () => assertTools());
 
 dispatch
   .command('issue')

--- a/lib/config.js
+++ b/lib/config.js
@@ -67,16 +67,6 @@ export function readActive() {
   }
 }
 
-export function writeActive(data) {
-  const configDir = getConfigDir();
-  if (!existsSync(configDir)) {
-    mkdirSync(configDir, { recursive: true });
-  }
-  const activePath = join(configDir, 'active.yaml');
-  const content = yaml.dump(data);
-  writeFileSync(activePath, content, 'utf8');
-}
-
 /**
  * Validate that a repo is onboarded by checking projects.yaml.
  * @param {string} repo - Repository in owner/repo format

--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { createWorktree } from './worktree.js';
+import { createWorktree, worktreeExists } from './worktree.js';
 import { createSymlink } from './symlink.js';
 import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
@@ -114,7 +114,7 @@ export async function dispatchIssue(options = {}) {
   // 4. Create worktree
   const worktreePath = join(resolvedRepoPath, '.worktrees', `rally-${number}`);
 
-  if (existsSync(worktreePath)) {
+  if (worktreeExists(resolvedRepoPath, worktreePath)) {
     console.error(`Warning: worktree already exists at ${worktreePath}, skipping creation`);
     return {
       branch,

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { createWorktree } from './worktree.js';
+import { createWorktree, worktreeExists } from './worktree.js';
 import { createSymlink } from './symlink.js';
 import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
@@ -112,7 +112,7 @@ export async function dispatchPr(options = {}) {
   // 4. Create worktree
   const worktreePath = join(resolvedRepoPath, '.worktrees', `rally-pr-${number}`);
 
-  if (existsSync(worktreePath)) {
+  if (worktreeExists(resolvedRepoPath, worktreePath)) {
     console.error(`Warning: worktree already exists at ${worktreePath}, skipping creation`);
     return {
       branch,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,8 +1,12 @@
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import { getConfigDir, writeConfig } from './config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
 
 /**
  * Runs the rally setup command.
@@ -65,7 +69,7 @@ export async function setup(options = {}) {
   const config = {
     teamDir,
     projectsDir,
-    version: '0.1.0',
+    version: pkg.version,
   };
   writeConfig(config);
   console.log(chalk.green('✓') + ` Saved config to ${join(configDir, 'config.yaml')}`);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import yaml from 'js-yaml';
 import {
   getConfigDir,
   readConfig,
@@ -10,7 +11,6 @@ import {
   readProjects,
   writeProjects,
   readActive,
-  writeActive
 } from '../lib/config.js';
 
 test('getConfigDir returns default path', () => {
@@ -236,7 +236,7 @@ test('readActive returns default when file is empty', () => {
   }
 });
 
-test('writeActive and readActive roundtrip', () => {
+test('readActive reads YAML written directly', () => {
   const originalEnv = process.env.RALLY_HOME;
   const tempDir = mkdtempSync(join(tmpdir(), 'rally-test-'));
   
@@ -248,7 +248,7 @@ test('writeActive and readActive roundtrip', () => {
       ]
     };
     
-    writeActive(data);
+    writeFileSync(join(tempDir, 'active.yaml'), yaml.dump(data), 'utf8');
     const result = readActive();
     
     assert.deepEqual(result, data);

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -169,8 +169,9 @@ describe('dispatchIssue error paths', () => {
     const issue = makeIssue();
     const exec = createExecWithIssue(issue);
 
-    // Pre-create the worktree directory
-    mkdirSync(join(repoPath, '.worktrees', 'rally-42'), { recursive: true });
+    // Create an actual git worktree so worktreeExists() returns true
+    const wtPath = join(repoPath, '.worktrees', 'rally-42');
+    execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/42-existing'], { cwd: repoPath, stdio: 'ignore' });
 
     const result = await dispatchIssue({ issueNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn });
     assert.strictEqual(result.existing, true);

--- a/test/dispatch-pr.test.js
+++ b/test/dispatch-pr.test.js
@@ -248,7 +248,9 @@ describe('dispatchPr error paths', () => {
     const pr = makePr();
     const exec = createExecWithPr(pr);
 
-    mkdirSync(join(repoPath, '.worktrees', 'rally-pr-42'), { recursive: true });
+    // Create an actual git worktree so worktreeExists() returns true
+    const wtPath = join(repoPath, '.worktrees', 'rally-pr-42');
+    execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/pr-42-existing'], { cwd: repoPath, stdio: 'ignore' });
 
     const result = await dispatchPr({ prNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn });
     assert.strictEqual(result.existing, true);

--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -153,7 +153,8 @@ describe('worktree collision detection', () => {
     const issue = makeIssue();
     const exec = createExecWithIssue(issue);
 
-    mkdirSync(join(repoPath, '.worktrees', 'rally-10'), { recursive: true });
+    // Create an actual git worktree so worktreeExists() returns true
+    execFileSync('git', ['worktree', 'add', join(repoPath, '.worktrees', 'rally-10'), '-b', 'rally/10-existing'], { cwd: repoPath, stdio: 'ignore' });
 
     const result = await dispatchIssue({
       issueNumber: 10,
@@ -174,7 +175,8 @@ describe('worktree collision detection', () => {
     const exec = createExecWithIssue(issue);
 
     const wtPath = join(repoPath, '.worktrees', 'rally-11');
-    mkdirSync(wtPath, { recursive: true });
+    // Create an actual git worktree so worktreeExists() returns true
+    execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/11-existing'], { cwd: repoPath, stdio: 'ignore' });
     writeFileSync(join(wtPath, 'marker.txt'), 'existing');
 
     const result = await dispatchIssue({

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -292,8 +292,9 @@ describe('Integration: error cases', () => {
     const issue = makeIssue();
     const exec = createExecWithIssue(issue);
 
-    // Pre-create the worktree directory
-    mkdirSync(join(repoPath, '.worktrees', 'rally-42'), { recursive: true });
+    // Create an actual git worktree so worktreeExists() returns true
+    const wtPath = join(repoPath, '.worktrees', 'rally-42');
+    execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/42-test-issue'], { cwd: repoPath, stdio: 'ignore' });
 
     const result = await dispatchIssue({
       issueNumber: 42,
@@ -333,7 +334,9 @@ describe('Integration: error cases', () => {
     setupRallyHome();
     const exec = createExecWithPr(makePr());
 
-    mkdirSync(join(repoPath, '.worktrees', 'rally-pr-42'), { recursive: true });
+    // Create an actual git worktree so worktreeExists() returns true
+    const wtPath = join(repoPath, '.worktrees', 'rally-pr-42');
+    execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/pr-42-test-pr'], { cwd: repoPath, stdio: 'ignore' });
 
     const result = await dispatchPr({
       prNumber: 42,

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -5,8 +5,10 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import yaml from 'js-yaml';
 import { getStatus, formatStatus } from '../lib/status.js';
-import { writeConfig, writeProjects, writeActive } from '../lib/config.js';
+import { writeConfig, writeProjects } from '../lib/config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -109,14 +111,14 @@ test('status: shows active dispatches (empty)', () => {
 });
 
 test('status: shows active dispatches (populated)', () => {
-  withTempHome(() => {
+  withTempHome((tempDir) => {
     const active = {
       dispatches: [
         { id: 42, project: 'app-one', status: 'implementing' },
         { id: 51, project: 'app-one', status: 'planning' },
       ]
     };
-    writeActive(active);
+    writeFileSync(join(tempDir, 'active.yaml'), yaml.dump(active), 'utf8');
     const status = getStatus();
     assert.strictEqual(status.dispatches.length, 2);
     assert.strictEqual(status.dispatches[0].id, 42);


### PR DESCRIPTION
## Changes

- **#59**: Call `assertTools()` via `preAction` hook on `dispatch` and `onboard` commands to catch missing CLI tools early
- **#60**: Remove redundant non-atomic `writeActive()` from `config.js`; update tests to write YAML directly
- **#63**: Read version from `package.json` at runtime in `bin/rally.js` and `lib/setup.js` instead of hardcoding `0.1.0`
- **#64**: Replace `existsSync(worktreePath)` with `worktreeExists(resolvedRepoPath, worktreePath)` in dispatch modules for proper git worktree detection

All tests passing.

Closes #59, #60, #63, #64