### PR TITLE
fix: clean up orphaned worktrees on dispatch failure (#61)

### DIFF
--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { createWorktree, worktreeExists } from './worktree.js';
+import { createWorktree, removeWorktree, worktreeExists } from './worktree.js';
 import { createSymlink } from './symlink.js';
 import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
@@ -35,8 +35,6 @@ export function slugify(title) {
  *  7. Launch Copilot CLI (gracefully skip if unavailable)
  *  8. Add dispatch to active.yaml with status "planning" and session_id
  *  9. Return session info
- *
- * TODO: Wrap steps 4-6 in try-catch to clean up worktree on failure (#40 follow-up)
  *
  * @param {object} options
  * @param {number|string} options.issueNumber - GitHub issue number
@@ -128,37 +126,48 @@ export async function dispatchIssue(options = {}) {
 
   createWorktree(resolvedRepoPath, worktreePath, branch);
 
-  // 5. Symlink squad into worktree
-  const squadSource = teamDir || join(resolvedRepoPath, '.squad');
-  const squadTarget = join(worktreePath, '.squad');
-  if (existsSync(squadSource)) {
-    createSymlink(squadSource, squadTarget);
-  }
-
-  // 6. Write dispatch-context.md
-  writeIssueContext(worktreePath, { ...issue, number });
-
-  // 7. Launch Copilot CLI
-  const prompt = `Read .squad/dispatch-context.md and plan/implement a fix for issue #${number}`;
   let copilotResult = { sessionId: null, process: null };
+  let dispatchId;
   try {
-    copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
-  } catch {
-    // Copilot CLI not available — gracefully skip
-  }
+    // 5. Symlink squad into worktree
+    const squadSource = teamDir || join(resolvedRepoPath, '.squad');
+    const squadTarget = join(worktreePath, '.squad');
+    if (existsSync(squadSource)) {
+      createSymlink(squadSource, squadTarget);
+    }
 
-  // 8. Add dispatch to active.yaml (after Copilot launch so session_id is captured)
-  const dispatchId = `${repo.split('/')[1]}-issue-${number}`;
-  addDispatch({
-    id: dispatchId,
-    repo,
-    number,
-    type: 'issue',
-    branch,
-    worktreePath,
-    status: 'planning',
-    session_id: copilotResult.sessionId || 'pending',
-  });
+    // 6. Write dispatch-context.md
+    writeIssueContext(worktreePath, { ...issue, number });
+
+    // 7. Launch Copilot CLI
+    const prompt = `Read .squad/dispatch-context.md and plan/implement a fix for issue #${number}`;
+    try {
+      copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
+    } catch {
+      // Copilot CLI not available — gracefully skip
+    }
+
+    // 8. Add dispatch to active.yaml (after Copilot launch so session_id is captured)
+    dispatchId = `${repo.split('/')[1]}-issue-${number}`;
+    addDispatch({
+      id: dispatchId,
+      repo,
+      number,
+      type: 'issue',
+      branch,
+      worktreePath,
+      status: 'planning',
+      session_id: copilotResult.sessionId || 'pending',
+    });
+  } catch (err) {
+    // Clean up orphaned worktree
+    try {
+      removeWorktree(resolvedRepoPath, worktreePath);
+    } catch {
+      // Best-effort cleanup — if this fails too, at least we tried
+    }
+    throw err;
+  }
 
   // 9. Return result
   return {

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { createWorktree, worktreeExists } from './worktree.js';
+import { createWorktree, removeWorktree, worktreeExists } from './worktree.js';
 import { createSymlink } from './symlink.js';
 import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
@@ -126,41 +126,52 @@ export async function dispatchPr(options = {}) {
 
   createWorktree(resolvedRepoPath, worktreePath, branch);
 
-  // Checkout PR's head ref so the worktree reflects the PR's code
-  _exec('git', ['-C', worktreePath, 'fetch', 'origin', pr.headRefName], { encoding: 'utf8', stdio: 'pipe' });
-  _exec('git', ['-C', worktreePath, 'reset', '--hard', 'FETCH_HEAD'], { encoding: 'utf8', stdio: 'pipe' });
-
-  // 5. Symlink squad into worktree
-  const squadSource = teamDir || join(resolvedRepoPath, '.squad');
-  const squadTarget = join(worktreePath, '.squad');
-  if (existsSync(squadSource)) {
-    createSymlink(squadSource, squadTarget);
-  }
-
-  // 6. Write dispatch-context.md
-  writePrContext(worktreePath, { ...pr, number });
-
-  // 7. Launch Copilot CLI
-  const prompt = `Read .squad/dispatch-context.md and review PR #${number}`;
   let copilotResult = { sessionId: null, process: null };
+  let dispatchId;
   try {
-    copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
-  } catch {
-    // Copilot CLI not available — gracefully skip
-  }
+    // Checkout PR's head ref so the worktree reflects the PR's code
+    _exec('git', ['-C', worktreePath, 'fetch', 'origin', pr.headRefName], { encoding: 'utf8', stdio: 'pipe' });
+    _exec('git', ['-C', worktreePath, 'reset', '--hard', 'FETCH_HEAD'], { encoding: 'utf8', stdio: 'pipe' });
 
-  // 8. Add dispatch to active.yaml
-  const dispatchId = `${repoName}-pr-${number}`;
-  addDispatch({
-    id: dispatchId,
-    repo,
-    number,
-    type: 'pr',
-    branch,
-    worktreePath,
-    status: 'reviewing',
-    session_id: copilotResult.sessionId || 'pending',
-  });
+    // 5. Symlink squad into worktree
+    const squadSource = teamDir || join(resolvedRepoPath, '.squad');
+    const squadTarget = join(worktreePath, '.squad');
+    if (existsSync(squadSource)) {
+      createSymlink(squadSource, squadTarget);
+    }
+
+    // 6. Write dispatch-context.md
+    writePrContext(worktreePath, { ...pr, number });
+
+    // 7. Launch Copilot CLI
+    const prompt = `Read .squad/dispatch-context.md and review PR #${number}`;
+    try {
+      copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
+    } catch {
+      // Copilot CLI not available — gracefully skip
+    }
+
+    // 8. Add dispatch to active.yaml
+    dispatchId = `${repoName}-pr-${number}`;
+    addDispatch({
+      id: dispatchId,
+      repo,
+      number,
+      type: 'pr',
+      branch,
+      worktreePath,
+      status: 'reviewing',
+      session_id: copilotResult.sessionId || 'pending',
+    });
+  } catch (err) {
+    // Clean up orphaned worktree
+    try {
+      removeWorktree(resolvedRepoPath, worktreePath);
+    } catch {
+      // Best-effort cleanup — if this fails too, at least we tried
+    }
+    throw err;
+  }
 
   // 9. Return result
   return {

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -361,4 +361,39 @@ describe('dispatchIssue happy path', () => {
     // Worktree and active.yaml should still be set up
     assert.ok(existsSync(result.worktreePath));
   });
+
+  test('cleans up worktree when post-creation step fails', async () => {
+    setupRallyHome();
+    const issue = makeIssue();
+
+    // _exec that succeeds for gh + git but makes addDispatch fail
+    const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
+        return JSON.stringify(issue);
+      }
+      return execFileSync(cmd, args, opts);
+    };
+
+    mkdirSync(join(repoPath, '.squad'), { recursive: true });
+
+    // Make active.yaml a directory so addDispatch throws
+    const activePath = join(process.env.RALLY_HOME, 'active.yaml');
+    mkdirSync(activePath, { recursive: true });
+    writeFileSync(join(activePath, 'blocker'), 'x');
+
+    const worktreePath = join(repoPath, '.worktrees', 'rally-88');
+
+    await assert.rejects(
+      () => dispatchIssue({
+        issueNumber: 88,
+        repo: 'owner/repo',
+        repoPath,
+        _exec: exec,
+        _spawn: noopSpawn,
+      }),
+    );
+
+    // Worktree directory should be cleaned up
+    assert.ok(!existsSync(worktreePath), 'worktree should be removed after failure');
+  });
 });


### PR DESCRIPTION
## Problem

In both `dispatch-issue.js` and `dispatch-pr.js`, if worktree creation succeeds but later steps fail (context writing, addDispatch, copilot launch, git fetch), the worktree is orphaned — it exists on disk and in git but is not tracked in active.yaml.

## Fix

Wrapped post-worktree-creation steps (symlink, context write, Copilot launch, addDispatch) in a try-catch. On failure, the worktree is cleaned up via `removeWorktree()` before re-throwing.

Applied the same pattern to both `dispatch-issue.js` and `dispatch-pr.js`.

## Test

Added a test in `dispatch-issue.test.js` that verifies worktree cleanup on failure by making `addDispatch` fail (active.yaml is a directory) and asserting the worktree directory no longer exists.

All tests pass.

Closes #61