### PR TITLE
docs: add dispatch commands to README, annotate planned API (#78, #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CLI tool for dispatching AI coding agents (Squad teams) to GitHub issues via git
 ## Installation
 
 ```bash
-npm install -g rally-cli
+npm install -g rally
 ```
 
 Or run directly with npx:
@@ -25,6 +25,8 @@ npx rally
 ```bash
 rally setup              # Configure team directory
 rally onboard <url>      # Clone and set up a repository
+rally dispatch issue 42  # Dispatch Squad to an issue
+rally dispatch pr 10     # Dispatch Squad to a PR review
 rally dashboard          # View active dispatches
 rally dashboard clean    # Remove completed dispatches
 ```
@@ -96,6 +98,46 @@ Options:
 ```
 
 **Keyboard shortcuts (interactive mode):** ↑/↓ navigate, Enter select, r refresh, q quit.
+
+### `rally dispatch issue`
+
+Dispatch Squad to a GitHub issue. Creates a worktree, symlinks Squad, writes context, and launches Copilot CLI.
+
+```
+$ rally dispatch issue --help
+Usage: rally dispatch issue [options] <number>
+
+Dispatch Squad to a GitHub issue
+
+Arguments:
+  number                 GitHub issue number
+
+Options:
+  --repo <owner/repo>    Target repository (owner/repo)
+  --repo-path <path>     Path to local repo clone
+  --team-dir <path>      Path to custom squad directory
+  -h, --help             display help for command
+```
+
+### `rally dispatch pr`
+
+Dispatch Squad to a GitHub PR review. Creates a worktree checked out to the PR head, symlinks Squad, and launches Copilot CLI.
+
+```
+$ rally dispatch pr --help
+Usage: rally dispatch pr [options] <number>
+
+Dispatch Squad to a GitHub PR review
+
+Arguments:
+  number                 GitHub PR number
+
+Options:
+  --repo <owner/repo>    Target repository (owner/repo)
+  --repo-path <path>     Path to local repo clone
+  --team-dir <path>      Path to custom squad directory
+  -h, --help             display help for command
+```
 
 ## License
 

--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -6,6 +6,7 @@ import { execFileSync, spawn } from 'node:child_process';
  * @param {Function} [opts._exec] - Injectable execFileSync (for testing)
  * @returns {boolean} true if gh copilot is available
  */
+// Used as a pre-check utility; currently tested but not called in dispatch flows
 export function checkCopilotAvailable(opts = {}) {
   const exec = opts._exec || execFileSync;
   try {

--- a/lib/exclude.js
+++ b/lib/exclude.js
@@ -53,6 +53,7 @@ export function addExcludes(gitDir, entries) {
   writeFileSync(excludePath, content, 'utf8');
 }
 
+// Planned for offboard command
 export function removeExcludes(gitDir, entries) {
   const excludePath = join(gitDir, 'info', 'exclude');
   
@@ -74,6 +75,7 @@ export function removeExcludes(gitDir, entries) {
   writeFileSync(excludePath, content, 'utf8');
 }
 
+// Planned for offboard command
 export function hasExcludes(gitDir, entries) {
   const excludePath = join(gitDir, 'info', 'exclude');
   

--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -29,6 +29,7 @@ export function createSymlink(target, linkPath) {
   symlinkSync(target, linkPath, type);
 }
 
+// Planned for offboard command
 export function validateSymlink(linkPath) {
   if (!existsSync(linkPath)) {
     return false;
@@ -47,6 +48,7 @@ export function validateSymlink(linkPath) {
   }
 }
 
+// Planned for offboard command
 export function removeSymlink(linkPath) {
   if (!existsSync(linkPath)) {
     return;


### PR DESCRIPTION
Fixes #78, fixes #79

**Changes:**
- Document `rally dispatch issue` and `rally dispatch pr` in README with usage examples
- Fix package name mismatch: `rally-cli` → `rally`
- Add dispatch commands to Quick Start section
- Annotate unused exports (`checkCopilotAvailable`, `validateSymlink`, `removeSymlink`, `removeExcludes`, `hasExcludes`) as planned offboard API rather than deleting