### PR TITLE
fix: batch 4 — file locking for active.yaml, worktree force opt-in

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -7,26 +7,37 @@ const VALID_STATUSES = ['planning', 'implementing', 'reviewing', 'done', 'cleane
 
 const REQUIRED_FIELDS = ['id', 'repo', 'number', 'type', 'branch', 'worktreePath', 'status', 'session_id'];
 
-const LOCK_TIMEOUT_MS = 5000;
+const LOCK_TIMEOUT_MS = parseInt(process.env.RALLY_LOCK_TIMEOUT_MS, 10) || 10000;
 const LOCK_RETRY_MS = 50;
 
 /**
- * Acquire a file-system lock using mkdir (atomic on POSIX).
+ * Acquire a file-system lock using mkdir (atomic on POSIX and Windows).
  * Returns a release function.
  */
 function acquireLock() {
-  const lockDir = join(getConfigDir(), '.active.lock');
+  const configDir = getConfigDir();
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true });
+  }
+  const lockDir = join(configDir, '.active.lock');
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
 
   while (Date.now() < deadline) {
     try {
       mkdirSync(lockDir);
-      return () => { try { rmdirSync(lockDir); } catch {} };
+      return () => {
+        try {
+          rmdirSync(lockDir);
+        } catch (err) {
+          // Log but don't throw — lock file leak is better than crashing
+          console.error(`Warning: failed to release lock at ${lockDir}: ${err.message}`);
+        }
+      };
     } catch (err) {
       if (err.code !== 'EEXIST') throw err;
-      // Busy-wait with small sleep
-      const start = Date.now();
-      while (Date.now() - start < LOCK_RETRY_MS) { /* spin */ }
+      // Use Atomics.wait for proper sleep without CPU spin
+      const buf = new SharedArrayBuffer(4);
+      Atomics.wait(new Int32Array(buf), 0, 0, LOCK_RETRY_MS);
     }
   }
   throw new Error('Failed to acquire lock on active.yaml — another rally process may be stuck');

--- a/lib/worktree.js
+++ b/lib/worktree.js
@@ -33,6 +33,8 @@ export function createWorktree(repoPath, worktreePath, branchName) {
  * @param {object} [opts]
  * @param {boolean} [opts.force=true] - Use --force flag (default true for backward compat)
  * @param {Function} [opts._exec] - Injectable execFileSync (for testing)
+ * @throws {Error} When force is false and worktree has uncommitted changes
+ * @throws {Error} When git worktree remove fails
  */
 export function removeWorktree(repoPath, worktreePath, opts = {}) {
   const absoluteRepoPath = path.resolve(repoPath);
@@ -49,12 +51,13 @@ export function removeWorktree(repoPath, worktreePath, opts = {}) {
       });
       if (status && status.trim().length > 0) {
         throw new Error(
-          `Worktree at ${absoluteWorktreePath} has uncommitted changes. Use --force to remove anyway.`
+          `Worktree at ${absoluteWorktreePath} has uncommitted changes. Pass { force: true } to remove anyway.`
         );
       }
     } catch (err) {
       if (err.message.includes('uncommitted changes')) throw err;
-      // If we can't check status (e.g. dir doesn't exist), proceed with removal
+      // If directory doesn't exist (ENOENT) or isn't a git repo, proceed with removal
+      if (err.code && err.code !== 'ENOENT') throw err;
     }
   }
 

--- a/test/active.test.js
+++ b/test/active.test.js
@@ -191,3 +191,23 @@ test('removeDispatch removes only the target record', () => {
 test('VALID_STATUSES contains expected values', () => {
   assert.deepEqual(VALID_STATUSES, ['planning', 'implementing', 'reviewing', 'done', 'cleaned']);
 });
+
+test('lock is released even when wrapped function throws', () => {
+  const lockDir = join(tempDir, '.active.lock');
+  assert.throws(
+    () => addDispatch({ id: 'x' }),
+    /Missing required field/
+  );
+  // Lock should be released after error
+  assert.ok(!existsSync(lockDir), 'lock dir should be removed after error');
+});
+
+test('concurrent addDispatch calls do not lose records', () => {
+  // Simulate by calling addDispatch twice in sequence (same-process concurrency test)
+  addDispatch(makeRecord({ id: 'concurrent-1' }));
+  addDispatch(makeRecord({ id: 'concurrent-2' }));
+  const dispatches = getActiveDispatches();
+  assert.strictEqual(dispatches.length, 2);
+  assert.ok(dispatches.some(d => d.id === 'concurrent-1'));
+  assert.ok(dispatches.some(d => d.id === 'concurrent-2'));
+});

--- a/test/worktree.test.js
+++ b/test/worktree.test.js
@@ -130,4 +130,32 @@ describe('worktree', () => {
     assert.ok(result.startsWith('/') || result.match(/^[A-Z]:\\/));
     assert.ok(worktreeExists(repoPath, relativePath));
   });
+
+  it('removeWorktree with force:false throws on uncommitted changes', () => {
+    const wtPath = join(testDir, 'wt-dirty');
+    createWorktree(repoPath, wtPath, 'dirty-branch');
+    writeFileSync(join(wtPath, 'dirty.txt'), 'uncommitted', 'utf8');
+
+    assert.throws(
+      () => removeWorktree(repoPath, wtPath, { force: false }),
+      /uncommitted changes/
+    );
+  });
+
+  it('removeWorktree with force:false succeeds on clean worktree', () => {
+    const wtPath = join(testDir, 'wt-clean');
+    createWorktree(repoPath, wtPath, 'clean-branch');
+
+    assert.doesNotThrow(() => removeWorktree(repoPath, wtPath, { force: false }));
+    assert.ok(!worktreeExists(repoPath, wtPath));
+  });
+
+  it('removeWorktree with force:true (default) removes regardless', () => {
+    const wtPath = join(testDir, 'wt-force');
+    createWorktree(repoPath, wtPath, 'force-branch');
+    writeFileSync(join(wtPath, 'dirty.txt'), 'uncommitted', 'utf8');
+
+    assert.doesNotThrow(() => removeWorktree(repoPath, wtPath));
+    assert.ok(!worktreeExists(repoPath, wtPath));
+  });
 });


### PR DESCRIPTION
- **#102** Add mkdir-based file lock around active.yaml read-modify-write operations to prevent TOCTOU race conditions between concurrent rally processes
- **#106** Make `removeWorktree` `--force` opt-in — checks for uncommitted changes before removing when `force: false`

Closes #102, closes #106