### PR TITLE
fix: batch 5 — rename blocked→orphaned, integrate checkCopilotAvailable

### DIFF
--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -6,7 +6,6 @@ import { execFileSync, spawn } from 'node:child_process';
  * @param {Function} [opts._exec] - Injectable execFileSync (for testing)
  * @returns {boolean} true if gh copilot is available
  */
-// Used as a pre-check utility; currently tested but not called in dispatch flows
 export function checkCopilotAvailable(opts = {}) {
   const exec = opts._exec || execFileSync;
   try {

--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -6,7 +6,7 @@ import { createSymlink } from './symlink.js';
 import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
 import { writeIssueContext } from './dispatch-context.js';
-import { launchCopilot } from './copilot.js';
+import { launchCopilot, checkCopilotAvailable } from './copilot.js';
 import { slugify } from './utils.js';
 
 
@@ -132,12 +132,14 @@ export async function dispatchIssue(options = {}) {
     // 6. Write dispatch-context.md
     writeIssueContext(worktreePath, { ...issue, number });
 
-    // 7. Launch Copilot CLI
-    const prompt = `Read .squad/dispatch-context.md and plan/implement a fix for issue #${number}`;
-    try {
-      copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
-    } catch {
-      // Copilot CLI not available — gracefully skip
+    // 7. Launch Copilot CLI (if available)
+    if (checkCopilotAvailable({ _exec })) {
+      const prompt = `Read .squad/dispatch-context.md and plan/implement a fix for issue #${number}`;
+      try {
+        copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
+      } catch {
+        // Copilot launch failed — continue without it
+      }
     }
 
     // 8. Add dispatch to active.yaml (after Copilot launch so session_id is captured)

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -7,7 +7,7 @@ import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
 import { writePrContext } from './dispatch-context.js';
 import { slugify } from './utils.js';
-import { launchCopilot } from './copilot.js';
+import { launchCopilot, checkCopilotAvailable } from './copilot.js';
 
 /**
  * Fetch a PR and validate it is open (not merged/closed).
@@ -167,12 +167,14 @@ export async function dispatchPr(options = {}) {
     // 6. Write dispatch-context.md
     writePrContext(worktreePath, { ...pr, number });
 
-    // 7. Launch Copilot CLI
-    const prompt = `Read .squad/dispatch-context.md and review PR #${number}`;
-    try {
-      copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
-    } catch {
-      // Copilot CLI not available — gracefully skip
+    // 7. Launch Copilot CLI (if available)
+    if (checkCopilotAvailable({ _exec })) {
+      const prompt = `Read .squad/dispatch-context.md and review PR #${number}`;
+      try {
+        copilotResult = launchCopilot(worktreePath, prompt, { _spawn });
+      } catch {
+        // Copilot launch failed — continue without it
+      }
     }
 
     // 8. Add dispatch to active.yaml

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -16,7 +16,7 @@ function SummaryLine({ summary }) {
         <Text> · </Text>
         <Text bold color="blue">{summary.done} done</Text>
         <Text> · </Text>
-        <Text bold color="red">{summary.blocked} blocked</Text>
+        <Text bold color="red">{summary.orphaned} orphaned</Text>
       </Text>
     </Box>
   );

--- a/lib/ui/dashboard-data.js
+++ b/lib/ui/dashboard-data.js
@@ -34,19 +34,19 @@ export function checkWorktreeHealth(dispatches) {
 export function computeSummary(dispatches) {
   let active = 0;
   let done = 0;
-  let blocked = 0;
+  let orphaned = 0;
 
   for (const d of dispatches) {
     if (d.status === 'done' || d.status === 'cleaned') {
       done++;
     } else if (!d.healthy) {
-      blocked++;
+      orphaned++;
     } else {
       active++;
     }
   }
 
-  return { active, done, blocked };
+  return { active, done, orphaned };
 }
 
 /**
@@ -102,7 +102,7 @@ export function renderPlainDashboard({ project } = {}) {
   }
 
   lines.push('');
-  lines.push(`${summary.active} active · ${summary.done} done · ${summary.blocked} blocked`);
+  lines.push(`${summary.active} active · ${summary.done} done · ${summary.orphaned} orphaned`);
 
   return lines.join('\n');
 }

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -78,6 +78,9 @@ function createExecWithIssue(issueData) {
       }
       return JSON.stringify(issueData);
     }
+    if (cmd === 'gh' && args[0] === 'copilot') {
+      return ''; // Copilot is "available" in tests
+    }
     // Delegate git commands to real git
     return execFileSync(cmd, args, opts);
   };

--- a/test/dispatch-pr.test.js
+++ b/test/dispatch-pr.test.js
@@ -91,6 +91,9 @@ function createExecWithPr(prData) {
       }
       return JSON.stringify(prData);
     }
+    if (cmd === 'gh' && args[0] === 'copilot') {
+      return ''; // Copilot is "available" in tests
+    }
     // Simulate refs/pull/N/head fetch — in tests, fetch the PR branch directly
     if (cmd === 'git' && args.includes('fetch') && args.some(a => a.startsWith('refs/pull/'))) {
       const cFlag = args.indexOf('-C');

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -420,9 +420,9 @@ describe('Integration: dashboard data and rendering', () => {
     assert.strictEqual(data.dispatches[1].healthy, false);
     assert.strictEqual(data.dispatches[2].healthy, false);
 
-    // Summary: d1 = active (healthy+implementing), d2 = blocked (unhealthy+reviewing), d3 = done
+    // Summary: d1 = active (healthy+implementing), d2 = orphaned (unhealthy+reviewing), d3 = done
     assert.strictEqual(data.summary.active, 1);
-    assert.strictEqual(data.summary.blocked, 1);
+    assert.strictEqual(data.summary.orphaned, 1);
     assert.strictEqual(data.summary.done, 1);
   });
 
@@ -437,7 +437,7 @@ describe('Integration: dashboard data and rendering', () => {
     const summary = computeSummary(dispatches);
     assert.strictEqual(summary.active, 2);
     assert.strictEqual(summary.done, 2);
-    assert.strictEqual(summary.blocked, 1);
+    assert.strictEqual(summary.orphaned, 1);
   });
 
   test('renderPlainDashboard outputs formatted text', () => {
@@ -514,7 +514,7 @@ describe('Integration: dashboard data and rendering', () => {
   test('getDashboardData returns empty when no dispatches', () => {
     const data = getDashboardData();
     assert.strictEqual(data.dispatches.length, 0);
-    assert.deepStrictEqual(data.summary, { active: 0, done: 0, blocked: 0 });
+    assert.deepStrictEqual(data.summary, { active: 0, done: 0, orphaned: 0 });
   });
 });
 

--- a/test/non-tty.test.js
+++ b/test/non-tty.test.js
@@ -96,7 +96,7 @@ describe('renderPlainDashboard (non-TTY)', () => {
     const output = renderPlainDashboard();
     assert.ok(output.includes('1 active'), 'should show active count');
     assert.ok(output.includes('1 done'), 'should show done count');
-    assert.ok(output.includes('blocked'), 'should show blocked label');
+    assert.ok(output.includes('orphaned'), 'should show orphaned label');
   });
 
   it('filters by project', () => {

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -84,7 +84,7 @@ function setupWithDispatches() {
 }
 
 describe('computeSummary', () => {
-  it('counts active, done, and blocked dispatches', () => {
+  it('counts active, done, and orphaned dispatches', () => {
     const dispatches = [
       { status: 'implementing', healthy: true },
       { status: 'done', healthy: true },
@@ -94,14 +94,14 @@ describe('computeSummary', () => {
     const summary = computeSummary(dispatches);
     assert.equal(summary.active, 1);
     assert.equal(summary.done, 2);
-    assert.equal(summary.blocked, 1);
+    assert.equal(summary.orphaned, 1);
   });
 
   it('returns zeros for empty array', () => {
     const summary = computeSummary([]);
     assert.equal(summary.active, 0);
     assert.equal(summary.done, 0);
-    assert.equal(summary.blocked, 0);
+    assert.equal(summary.orphaned, 0);
   });
 });
 
@@ -127,11 +127,11 @@ describe('getDashboardData', () => {
     const data = getDashboardData();
     assert.equal(typeof data.summary.active, 'number');
     assert.equal(typeof data.summary.done, 'number');
-    assert.equal(typeof data.summary.blocked, 'number');
-    // d1=implementing+healthy → active, d2=done → done, d3=planning+unhealthy → blocked
+    assert.equal(typeof data.summary.orphaned, 'number');
+    // d1=implementing+healthy → active, d2=done → done, d3=planning+unhealthy → orphaned
     assert.equal(data.summary.active, 1);
     assert.equal(data.summary.done, 1);
-    assert.equal(data.summary.blocked, 1);
+    assert.equal(data.summary.orphaned, 1);
   });
 
   it('filters by project name', () => {
@@ -149,7 +149,7 @@ describe('getDashboardData', () => {
     setupTestEnv([]);
     const data = getDashboardData();
     assert.equal(data.dispatches.length, 0);
-    assert.deepEqual(data.summary, { active: 0, done: 0, blocked: 0 });
+    assert.deepEqual(data.summary, { active: 0, done: 0, orphaned: 0 });
   });
 });
 
@@ -184,7 +184,7 @@ describe('Dashboard component', () => {
     const output = instance.lastFrame();
     assert.ok(output.includes('1 active'), 'should show active count');
     assert.ok(output.includes('1 done'), 'should show done count');
-    assert.ok(output.includes('1 blocked'), 'should show blocked count');
+    assert.ok(output.includes('1 orphaned'), 'should show orphaned count');
   });
 
   it('filters by project prop', () => {


### PR DESCRIPTION
- **#109** Rename 'blocked' to 'orphaned' for missing worktree dispatches — more accurate label since worktrees may just be on another machine
- **#111** Integrate `checkCopilotAvailable` as pre-check in dispatch-issue.js and dispatch-pr.js — avoids unnecessary spawn overhead when Copilot is missing
- Remove dead code comment from copilot.js

Closes #109, closes #111