### PR TITLE
rename blocked→orphaned, copilot precheck cleanup

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -347,7 +347,7 @@ Rally Dashboard
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
- 3 active · 1 done · 0 blocked
+ 3 active · 1 done · 0 orphaned
 ```
 
 **Options:**
@@ -846,7 +846,7 @@ All UI output must work in two modes. Chalk and Ink handle most of this automati
 │  api-srv    PR #87  feature/refactor-auth          ● reviewing     1d       │
 │  my-app     #38     rally/38-update-deps      ✓ done          3d       │
 │                                                                              │
-│  3 active · 1 done · 0 blocked                                              │
+│  3 active · 1 done · 0 orphaned                                              │
 │                                                                              │
 │  ────────────────────────────────────────────────────────────────────────── │
 │  q quit · r refresh · c clean done · ↑↓ select · enter open                 │
@@ -865,7 +865,7 @@ my-app     #42     rally/42-add-user-auth         implementing  2h
 my-app     #51     rally/51-fix-login-bug         planning      30m
 api-srv    PR #87  feature/refactor-auth               reviewing     1d
 
-3 active · 0 done · 0 blocked
+3 active · 0 done · 0 orphaned
 ```
 
 ---

--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -6,7 +6,6 @@ import { execFileSync, spawn } from 'node:child_process';
  * @param {Function} [opts._exec] - Injectable execFileSync (for testing)
  * @returns {boolean} true if gh copilot is available
  */
-// Used as a pre-check utility; currently tested but not called in dispatch flows
 export function checkCopilotAvailable(opts = {}) {
   const exec = opts._exec || execFileSync;
   try {

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -16,7 +16,7 @@ function SummaryLine({ summary }) {
         <Text> · </Text>
         <Text bold color="blue">{summary.done} done</Text>
         <Text> · </Text>
-        <Text bold color="red">{summary.blocked} blocked</Text>
+        <Text bold color="red">{summary.orphaned} orphaned</Text>
       </Text>
     </Box>
   );

--- a/lib/ui/dashboard-data.js
+++ b/lib/ui/dashboard-data.js
@@ -34,19 +34,19 @@ export function checkWorktreeHealth(dispatches) {
 export function computeSummary(dispatches) {
   let active = 0;
   let done = 0;
-  let blocked = 0;
+  let orphaned = 0;
 
   for (const d of dispatches) {
     if (d.status === 'done' || d.status === 'cleaned') {
       done++;
     } else if (!d.healthy) {
-      blocked++;
+      orphaned++;
     } else {
       active++;
     }
   }
 
-  return { active, done, blocked };
+  return { active, done, orphaned };
 }
 
 /**
@@ -102,7 +102,7 @@ export function renderPlainDashboard({ project } = {}) {
   }
 
   lines.push('');
-  lines.push(`${summary.active} active · ${summary.done} done · ${summary.blocked} blocked`);
+  lines.push(`${summary.active} active · ${summary.done} done · ${summary.orphaned} orphaned`);
 
   return lines.join('\n');
 }

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -400,6 +400,36 @@ describe('dispatchIssue happy path', () => {
     assert.ok(existsSync(result.worktreePath));
   });
 
+  test('skips Copilot launch when checkCopilotAvailable returns false', async () => {
+    setupRallyHome();
+    const issue = makeIssue();
+    let spawnCalled = false;
+
+    // _exec that fails for copilot check (not installed)
+    const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
+        return JSON.stringify(issue);
+      }
+      if (cmd === 'gh' && args[0] === 'copilot') {
+        throw new Error('gh copilot not installed');
+      }
+      return execFileSync(cmd, args, opts);
+    };
+
+    mkdirSync(join(repoPath, '.squad'), { recursive: true });
+
+    const result = await dispatchIssue({
+      issueNumber: 66,
+      repo: 'owner/repo',
+      repoPath,
+      _exec: exec,
+      _spawn: () => { spawnCalled = true; return { pid: 1, unref() {} }; },
+    });
+
+    assert.strictEqual(result.sessionId, null);
+    assert.strictEqual(spawnCalled, false, 'spawn should not be called when copilot is unavailable');
+  });
+
   test('cleans up worktree when post-creation step fails', async () => {
     setupRallyHome();
     const issue = makeIssue();

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -420,9 +420,9 @@ describe('Integration: dashboard data and rendering', () => {
     assert.strictEqual(data.dispatches[1].healthy, false);
     assert.strictEqual(data.dispatches[2].healthy, false);
 
-    // Summary: d1 = active (healthy+implementing), d2 = blocked (unhealthy+reviewing), d3 = done
+    // Summary: d1 = active (healthy+implementing), d2 = orphaned (unhealthy+reviewing), d3 = done
     assert.strictEqual(data.summary.active, 1);
-    assert.strictEqual(data.summary.blocked, 1);
+    assert.strictEqual(data.summary.orphaned, 1);
     assert.strictEqual(data.summary.done, 1);
   });
 
@@ -437,7 +437,7 @@ describe('Integration: dashboard data and rendering', () => {
     const summary = computeSummary(dispatches);
     assert.strictEqual(summary.active, 2);
     assert.strictEqual(summary.done, 2);
-    assert.strictEqual(summary.blocked, 1);
+    assert.strictEqual(summary.orphaned, 1);
   });
 
   test('renderPlainDashboard outputs formatted text', () => {
@@ -514,7 +514,7 @@ describe('Integration: dashboard data and rendering', () => {
   test('getDashboardData returns empty when no dispatches', () => {
     const data = getDashboardData();
     assert.strictEqual(data.dispatches.length, 0);
-    assert.deepStrictEqual(data.summary, { active: 0, done: 0, blocked: 0 });
+    assert.deepStrictEqual(data.summary, { active: 0, done: 0, orphaned: 0 });
   });
 });
 

--- a/test/non-tty.test.js
+++ b/test/non-tty.test.js
@@ -96,7 +96,7 @@ describe('renderPlainDashboard (non-TTY)', () => {
     const output = renderPlainDashboard();
     assert.ok(output.includes('1 active'), 'should show active count');
     assert.ok(output.includes('1 done'), 'should show done count');
-    assert.ok(output.includes('blocked'), 'should show blocked label');
+    assert.ok(output.includes('orphaned'), 'should show orphaned label');
   });
 
   it('filters by project', () => {

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -84,7 +84,7 @@ function setupWithDispatches() {
 }
 
 describe('computeSummary', () => {
-  it('counts active, done, and blocked dispatches', () => {
+  it('counts active, done, and orphaned dispatches', () => {
     const dispatches = [
       { status: 'implementing', healthy: true },
       { status: 'done', healthy: true },
@@ -94,14 +94,14 @@ describe('computeSummary', () => {
     const summary = computeSummary(dispatches);
     assert.equal(summary.active, 1);
     assert.equal(summary.done, 2);
-    assert.equal(summary.blocked, 1);
+    assert.equal(summary.orphaned, 1);
   });
 
   it('returns zeros for empty array', () => {
     const summary = computeSummary([]);
     assert.equal(summary.active, 0);
     assert.equal(summary.done, 0);
-    assert.equal(summary.blocked, 0);
+    assert.equal(summary.orphaned, 0);
   });
 });
 
@@ -127,11 +127,11 @@ describe('getDashboardData', () => {
     const data = getDashboardData();
     assert.equal(typeof data.summary.active, 'number');
     assert.equal(typeof data.summary.done, 'number');
-    assert.equal(typeof data.summary.blocked, 'number');
-    // d1=implementing+healthy → active, d2=done → done, d3=planning+unhealthy → blocked
+    assert.equal(typeof data.summary.orphaned, 'number');
+    // d1=implementing+healthy → active, d2=done → done, d3=planning+unhealthy → orphaned
     assert.equal(data.summary.active, 1);
     assert.equal(data.summary.done, 1);
-    assert.equal(data.summary.blocked, 1);
+    assert.equal(data.summary.orphaned, 1);
   });
 
   it('filters by project name', () => {
@@ -149,7 +149,7 @@ describe('getDashboardData', () => {
     setupTestEnv([]);
     const data = getDashboardData();
     assert.equal(data.dispatches.length, 0);
-    assert.deepEqual(data.summary, { active: 0, done: 0, blocked: 0 });
+    assert.deepEqual(data.summary, { active: 0, done: 0, orphaned: 0 });
   });
 });
 
@@ -184,7 +184,7 @@ describe('Dashboard component', () => {
     const output = instance.lastFrame();
     assert.ok(output.includes('1 active'), 'should show active count');
     assert.ok(output.includes('1 done'), 'should show done count');
-    assert.ok(output.includes('1 blocked'), 'should show blocked count');
+    assert.ok(output.includes('1 orphaned'), 'should show orphaned count');
   });
 
   it('filters by project prop', () => {


### PR DESCRIPTION
## Changes

- Rename 'blocked' dispatch label to 'orphaned' across UI, tests, and docs
- Remove stale dead-code comment from copilot.js  
- Add test verifying dispatch skips Copilot launch when unavailable

Closes #109, closes #111