### PR TITLE
fix: use # not @ for npx GitHub tag syntax

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -51,7 +51,7 @@ export async function setup(options = {}) {
   } else {
     const spinner = (await import('ora')).default('Initializing Squad...').start();
     try {
-      exec('npx', ['github:bradygaster/squad@v0.5.2'], {
+      exec('npx', ['github:bradygaster/squad#v0.5.2'], {
         cwd: teamDir,
         stdio: 'pipe',
       });

--- a/lib/team.js
+++ b/lib/team.js
@@ -96,7 +96,7 @@ async function initTeamDir(teamDir, exec) {
   const squadDir = join(teamDir, '.squad');
   if (!existsSync(squadDir)) {
     try {
-      exec('npx', ['github:bradygaster/squad@v0.5.2'], {
+      exec('npx', ['github:bradygaster/squad#v0.5.2'], {
         cwd: teamDir,
         stdio: 'pipe',
       });

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -65,7 +65,7 @@ describe('setup', () => {
 
     assert.ok(execCalled, 'exec should have been called');
     assert.strictEqual(execArgs.cmd, 'npx');
-    assert.deepStrictEqual(execArgs.args, ['github:bradygaster/squad@v0.5.2']);
+    assert.deepStrictEqual(execArgs.args, ['github:bradygaster/squad#v0.5.2']);
     assert.strictEqual(execArgs.cwd, join(tempDir, 'team'));
   });
 


### PR DESCRIPTION
## Root Cause

`npx github:bradygaster/squad@v0.5.2` (with `@`) is silently misparsed by npm as a scoped package, causing it to resolve to `ssh://git@github.com/null/v0.5.2.git` — which fails with exit code 128 and no stderr output.

The correct npm/npx syntax for specifying a git tag on a GitHub shorthand is `#`:

```
github:bradygaster/squad#v0.5.2   ✅ fetches repo at tag v0.5.2
github:bradygaster/squad@v0.5.2   ❌ npm treats @v0.5.2 as a scope
```

## Changes

- `lib/setup.js`: `@v0.5.2` → `#v0.5.2`
- `lib/team.js`: `@v0.5.2` → `#v0.5.2`
- `test/setup.test.js`: Updated assertion to match

All 24 tests pass (setup + team).

Closes #125