### PR TITLE
fix: use -p flag for gh copilot CLI prompt format

### DIFF
--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -29,7 +29,7 @@ export function checkCopilotAvailable(opts = {}) {
 export function launchCopilot(worktreePath, prompt, opts = {}) {
   const spawnFn = opts._spawn || spawn;
   try {
-    const child = spawnFn('gh', ['copilot', 'workspace', prompt], {
+    const child = spawnFn('gh', ['copilot', '-p', `workspace ${prompt}`], {
       cwd: worktreePath,
       stdio: 'inherit',
       detached: true,

--- a/test/copilot.test.js
+++ b/test/copilot.test.js
@@ -42,7 +42,7 @@ describe('checkCopilotAvailable', () => {
 // =====================================================
 
 describe('launchCopilot', () => {
-  test('spawns gh copilot workspace with prompt', () => {
+  test('spawns gh copilot with -p flag and workspace prompt', () => {
     let captured;
     const mockSpawn = (cmd, args, opts) => {
       captured = { cmd, args, opts };
@@ -52,7 +52,7 @@ describe('launchCopilot', () => {
     launchCopilot('/path/to/worktree', 'my prompt', { _spawn: mockSpawn });
 
     assert.strictEqual(captured.cmd, 'gh');
-    assert.deepStrictEqual(captured.args, ['copilot', 'workspace', 'my prompt']);
+    assert.deepStrictEqual(captured.args, ['copilot', '-p', 'workspace my prompt']);
     assert.strictEqual(captured.opts.cwd, '/path/to/worktree');
     assert.strictEqual(captured.opts.stdio, 'inherit');
     assert.strictEqual(captured.opts.detached, true);


### PR DESCRIPTION
## Summary

The `gh copilot` CLI rejects the positional `workspace` subcommand syntax used in `launchCopilot()`. This fixes the command format to use the `-p` flag with the full `workspace <prompt>` string.

### Before
```
gh copilot workspace "Read .squad/dispatch-context.md and plan/implement a fix for issue #1249"
```
 `error: Invalid command format`

### After
```
gh copilot -p "workspace Read .squad/dispatch-context.md and plan/implement a fix for issue #1249"
```

### Changes
- `lib/copilot.js`: Changed spawn args from `['copilot', 'workspace', prompt]` to `['copilot', '-p', \`workspace ${prompt}\`]`
- `test/copilot.test.js`: Updated assertion to match new arg format

All 335 tests pass.

Fixes #127