### PR TITLE
fix: delete local branch when removing dispatch

### DIFF
--- a/lib/dispatch-remove.js
+++ b/lib/dispatch-remove.js
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import chalk from 'chalk';
 import ora from 'ora';
 import { getActiveDispatches, removeDispatch } from './active.js';
@@ -28,6 +29,7 @@ function findProjectPath(repo, _readProjects) {
  * @param {Function} [opts._removeDispatch] - Injectable for testing
  * @param {Function} [opts._removeWorktree] - Injectable for testing
  * @param {Function} [opts._readProjects] - Injectable for testing
+ * @param {Function} [opts._exec] - Injectable execFileSync for testing
  * @param {object} [opts._ora] - Injectable for testing
  * @param {object} [opts._chalk] - Injectable for testing
  * @returns {Promise<object>} The removed dispatch record
@@ -37,6 +39,7 @@ export async function dispatchRemove(number, opts = {}) {
   const _remove = opts._removeDispatch || removeDispatch;
   const _removeWt = opts._removeWorktree || removeWorktree;
   const _readProj = opts._readProjects || readProjects;
+  const _exec = opts._exec || execFileSync;
   const _ora = opts._ora || ora;
   const _chalk = opts._chalk || chalk;
 
@@ -72,12 +75,24 @@ export async function dispatchRemove(number, opts = {}) {
       }
     }
 
+    // Delete local branch (may already be gone or unmerged)
+    if (repoPath && dispatch.branch) {
+      try {
+        _exec('git', ['branch', '-D', dispatch.branch], {
+          cwd: repoPath,
+          encoding: 'utf8',
+        });
+      } catch {
+        // Branch may already be deleted or not exist locally
+      }
+    }
+
     // Remove from active.yaml
     _remove(dispatch.id);
 
     const typeLabel = dispatch.type === 'pr' ? 'PR' : 'Issue';
     spinner.succeed(
-      `${_chalk.green('Removed')} ${typeLabel} #${number} (branch ${_chalk.dim(dispatch.branch)} preserved)`
+      `${_chalk.green('Removed')} ${typeLabel} #${number} (branch ${_chalk.dim(dispatch.branch)} deleted)`
     );
     return dispatch;
   } catch (err) {

--- a/test/dispatch-remove.test.js
+++ b/test/dispatch-remove.test.js
@@ -53,16 +53,19 @@ test('dispatchRemove removes dispatch by number', async () => {
   addDispatch(makeRecord());
 
   let removedId = null;
+  let branchDeleted = null;
   const result = await dispatchRemove(42, {
     _removeDispatch: (id) => { removedId = id; },
     _removeWorktree: () => {},
     _readProjects: () => ({ projects: [{ name: 'rally', path: '/tmp/repo' }] }),
+    _exec: (_cmd, args) => { if (args[0] === 'branch') branchDeleted = args[2]; },
     _ora: silentOra,
     _chalk: silentChalk,
   });
 
   assert.strictEqual(result.number, 42);
   assert.strictEqual(removedId, 'rally-issue-42');
+  assert.strictEqual(branchDeleted, 'rally/42-fix-bug');
 });
 
 test('dispatchRemove throws on unknown number', async () => {
@@ -112,16 +115,19 @@ test('dispatchRemove handles missing worktree gracefully', async () => {
   addDispatch(makeRecord());
 
   let removedId = null;
+  let branchDeleted = null;
   const result = await dispatchRemove(42, {
     _removeDispatch: (id) => { removedId = id; },
     _removeWorktree: () => { throw new Error('worktree gone'); },
     _readProjects: () => ({ projects: [{ name: 'rally', path: '/tmp/repo' }] }),
+    _exec: (_cmd, args) => { if (args[0] === 'branch') branchDeleted = args[2]; },
     _ora: silentOra,
     _chalk: silentChalk,
   });
 
   assert.strictEqual(result.number, 42);
   assert.strictEqual(removedId, 'rally-issue-42');
+  assert.strictEqual(branchDeleted, 'rally/42-fix-bug');
 });
 
 test('dispatchRemove handles missing project path gracefully', async () => {
@@ -129,10 +135,12 @@ test('dispatchRemove handles missing project path gracefully', async () => {
 
   let worktreeRemoveCalled = false;
   let removedId = null;
+  let execCalled = false;
   const result = await dispatchRemove(42, {
     _removeDispatch: (id) => { removedId = id; },
     _removeWorktree: () => { worktreeRemoveCalled = true; },
     _readProjects: () => ({ projects: [] }),
+    _exec: () => { execCalled = true; },
     _ora: silentOra,
     _chalk: silentChalk,
   });
@@ -140,4 +148,22 @@ test('dispatchRemove handles missing project path gracefully', async () => {
   assert.strictEqual(result.number, 42);
   assert.strictEqual(removedId, 'rally-issue-42');
   assert.strictEqual(worktreeRemoveCalled, false);
+  assert.strictEqual(execCalled, false, 'should not try to delete branch without project path');
+});
+
+test('dispatchRemove handles branch deletion failure gracefully', async () => {
+  addDispatch(makeRecord());
+
+  let removedId = null;
+  const result = await dispatchRemove(42, {
+    _removeDispatch: (id) => { removedId = id; },
+    _removeWorktree: () => {},
+    _readProjects: () => ({ projects: [{ name: 'rally', path: '/tmp/repo' }] }),
+    _exec: () => { throw new Error('branch not found'); },
+    _ora: silentOra,
+    _chalk: silentChalk,
+  });
+
+  assert.strictEqual(result.number, 42);
+  assert.strictEqual(removedId, 'rally-issue-42');
 });


### PR DESCRIPTION
## Problem

`rally dispatch remove` removes the worktree and active.yaml record but leaves the local git branch behind. When the user dispatches the same issue again, `git worktree add -b <branch>` fails with `fatal: a branch named '...' already exists`.

## Fix

After removing the worktree, `dispatch remove` now runs `git branch -D <branch>` to delete the local branch. Branch deletion failures are handled gracefully (branch may already be gone or not exist locally).

## Tests

- Existing tests updated to verify branch deletion occurs
- New test: branch deletion failure handled gracefully
- All 7 tests pass

Fixes #133