### PR TITLE
chore: update squad state — history, directives, decisions

### DIFF
--- a/.squad/agents/kaylee/history.md
+++ b/.squad/agents/kaylee/history.md
@@ -438,3 +438,35 @@ See GitHub issues #1–#8 (Phase 1) for detailed specs. All blockers resolved—
 - `test/dispatch-remove.test.js` — 6 tests: remove by number, unknown number, disambiguate with --repo, ambiguous without --repo, missing worktree, missing project path.
 
 **Key Learning:** The `findProjectPath()` helper is duplicated between `dashboard-clean.js` and `dispatch-remove.js` — both resolve a repo name to a local path via projects.yaml. Could be extracted to a shared utility in the future.
+
+### 2026-02-23 — Copilot Log Redirection (#135)
+
+**Issue:** Copilot CLI stdout/stderr was bleeding into user terminal due to `stdio: 'inherit'`
+
+**Solution implemented:**
+- Modified `lib/copilot.js` → `launchCopilot()` now accepts `logPath` parameter and redirects stdout/stderr to log file using `fs.openSync()` with `stdio: ['ignore', fd, fd]`
+- Updated `lib/dispatch-core.js` → `setupDispatchWorktree()` computes log path as `join(worktreePath, '.copilot-output.log')` and passes to `launchCopilot()`
+- Extended `lib/active.js` → `addDispatch()` now persists optional `logPath` field in dispatch records
+- Created `lib/dispatch-log.js` → new `dispatchLog(number, opts)` command finds dispatch by number, reads log file, outputs to terminal
+- Added `rally dispatch log <number> [--repo] [--follow]` command to `bin/rally.js`
+- `--follow` flag accepted but shows "not yet implemented" message (placeholder for future tail -f feature)
+
+**Testing:**
+- Updated `test/copilot.test.js` with new logPath parameter tests (fs.openSync/closeSync injection)
+- Created `test/dispatch-log.test.js` with 7 test cases (happy path, missing logPath, missing file, disambiguation, --follow stub)
+- All tests pass (69 tests across copilot, dispatch-log, active, dispatch-issue, dispatch-remove)
+
+**Key patterns:**
+- DI pattern: Injectable `_fs` parameter with `openSync` and `closeSync` for testing
+- Log file location: `.copilot-output.log` in worktree root (alongside `.squad` symlink)
+- Return value extension: `launchCopilot()` now returns `{ sessionId, process, logPath }` (was just sessionId/process)
+- File descriptor management: fd opened, passed to spawn, immediately closed (child inherits open fd)
+
+**Files modified:**
+- `lib/copilot.js` — log redirection logic
+- `lib/dispatch-core.js` — log path computation and pass-through
+- `lib/active.js` — logPath field support
+- `bin/rally.js` — new `dispatch log` command
+- `test/copilot.test.js` — updated tests
+- `lib/dispatch-log.js` — new command implementation
+- `test/dispatch-log.test.js` — new test suite

--- a/.squad/decisions/inbox/copilot-directive-2026-02-23T2055.md
+++ b/.squad/decisions/inbox/copilot-directive-2026-02-23T2055.md
@@ -1,0 +1,4 @@
+### 2026-02-23T20:55:15Z: User directive
+**By:** James Sturtevant (via Copilot)
+**What:** Always reply to Copilot review comments when resolving them — don't just resolve silently.
+**Why:** User request — captured for team memory

--- a/.squad/decisions/inbox/kaylee-copilot-log-redirect.md
+++ b/.squad/decisions/inbox/kaylee-copilot-log-redirect.md
@@ -1,0 +1,78 @@
+# Decision: Copilot Log Redirection Strategy
+
+**Author:** Kaylee (Core Dev)  
+**Date:** 2026-02-23  
+**Context:** Issue #135 — Copilot CLI output bleeding into user terminal  
+
+## Problem
+
+When `rally dispatch issue` launches `gh copilot` as a background process with `stdio: 'inherit'`, Copilot's output pollutes the user's terminal. Users want clean terminal output and the ability to review Copilot logs later.
+
+## Decision
+
+**Redirect Copilot stdout/stderr to a log file in the worktree.**
+
+### Implementation Details
+
+1. **Log file location:** `.copilot-output.log` in worktree root (same directory as `.squad` symlink)
+   - Consistent path pattern: `join(worktreePath, '.copilot-output.log')`
+   - Lives alongside worktree, gets cleaned up when worktree is removed
+   - Hidden file (dotfile) to avoid cluttering user's view
+
+2. **File descriptor management:** 
+   - Use `fs.openSync(logPath, 'w')` to get fd
+   - Pass `stdio: ['ignore', fd, fd]` to spawn (stdout and stderr both to log)
+   - Immediately `fs.closeSync(fd)` after spawn (child inherits the open fd)
+   - stdin ignored (Copilot is non-interactive in this mode)
+
+3. **State tracking:**
+   - Add optional `logPath` field to dispatch records in `active.yaml`
+   - Persisted during `addDispatch()` call in `setupDispatchWorktree()`
+   - Enables retrieval with `rally dispatch log <number>`
+
+4. **New command:** `rally dispatch log <number> [--repo] [--follow]`
+   - Finds dispatch by number (same disambiguation logic as `dispatch remove`)
+   - Reads and displays log file content
+   - Graceful degradation: warns if logPath missing or file not found
+   - `--follow` flag accepted but not yet implemented (placeholder for future)
+
+### Alternatives Considered
+
+- **Pipe to `tee`:** Rejected — too shell-specific, not cross-platform
+- **Separate stdout/stderr files:** Rejected — single unified log is simpler for users
+- **Global log directory:** Rejected — worktree-local keeps cleanup atomic
+- **No redirection + terminal multiplexing:** Rejected — forces user to manage terminal state
+
+## Impact
+
+### User-Facing
+- ✅ Clean terminal output during dispatch
+- ✅ Logs are retrievable: `rally dispatch log <number>`
+- ✅ Logs cleaned up automatically when dispatch removed
+- ⚠️ Pre-existing dispatches (created before this change) won't have logs
+
+### Developer-Facing
+- `launchCopilot()` signature extended with `logPath` parameter
+- Return value extended from `{ sessionId, process }` to `{ sessionId, process, logPath }`
+- All callers must be updated (currently only `setupDispatchWorktree()`)
+- DI pattern extended: `_fs` parameter with `openSync`/`closeSync` for testing
+
+### Testing
+- 7 new test cases in `test/dispatch-log.test.js`
+- 3 new test cases in `test/copilot.test.js` for log redirection
+- All existing tests continue to pass (backward compatible — logPath is optional)
+
+## Follow-Up Work
+
+1. **Implement `--follow` flag** — tail -f style log streaming (future issue)
+2. **Log rotation** — if log files grow too large (not currently a concern)
+3. **Log file compression** — for long-running dispatches (future optimization)
+
+## Rationale
+
+This approach is:
+- **Simple:** Single log file per dispatch, standard fs APIs
+- **Discoverable:** `rally dispatch log` mirrors `rally dispatch remove` UX
+- **Atomic:** Log lifecycle tied to worktree lifecycle
+- **Testable:** Full DI pattern, no global state, clean mocking
+- **Cross-platform:** Pure Node.js fs module, works on Windows/macOS/Linux


### PR DESCRIPTION
Updates squad team state from this session:

- **Kaylee's history.md**: Learnings from copilot log redirect feature (#135/#137)
- **Directive**: Always reply to Copilot review comments before resolving threads
- **Decision inbox**: Copilot log redirect architecture (logPath in active.yaml, .copilot-output.log per worktree)

No code changes — squad memory only.