### PR TITLE
docs: move Docker sandbox section below Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,6 @@ Rally is for individual developers using [Squad](https://bradygaster.github.io/s
 - [git](https://git-scm.com/)
 - [GitHub CLI (`gh`)](https://cli.github.com/)
 
-### Docker Sandbox (Optional)
-
-For enhanced isolation, Rally can run Copilot inside a [Docker sandbox](https://docs.docker.com/ai/sandboxes/agents/copilot/) microVM:
-
-- [Docker Desktop 4.58+](https://www.docker.com/products/docker-desktop/) with sandbox support
-- `GH_TOKEN` or `GITHUB_TOKEN` set globally in shell config
-- Docker Desktop restarted after setting the token
-
-Use `--sandbox` with dispatch commands:
-```bash
-rally dispatch issue 42 --sandbox
-rally dispatch pr 10 --sandbox
-```
-
 ## Installation
 
 Run directly with npx from GitHub:
@@ -56,6 +42,20 @@ rally dispatch issue 42  # Dispatch Squad to an issue
 rally dispatch pr 10     # Dispatch Squad to a PR review
 rally dashboard          # View active dispatches
 rally dashboard clean    # Remove completed dispatches
+```
+
+### Docker Sandbox (Optional)
+
+For enhanced isolation, Rally can run Copilot inside a [Docker sandbox](https://docs.docker.com/ai/sandboxes/agents/copilot/) microVM:
+
+- [Docker Desktop 4.58+](https://www.docker.com/products/docker-desktop/) with sandbox support
+- `GH_TOKEN` or `GITHUB_TOKEN` set globally in shell config
+- Docker Desktop restarted after setting the token
+
+Use `--sandbox` with dispatch commands:
+```bash
+rally dispatch issue 42 --sandbox
+rally dispatch pr 10 --sandbox
 ```
 
 ## Commands


### PR DESCRIPTION
Moves the **Docker Sandbox (Optional)** subsection from under Requirements to after the Quick Start section, improving the README flow for new users.

Closes #165

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>