### PR TITLE
fix: add .npmignore to control published files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# Ignore everything by default
+*
+
+# Include published package files
+!bin/
+!bin/**
+!lib/
+!lib/**
+!package.json
+!README.md
+!LICENSE
+!CHANGELOG.md


### PR DESCRIPTION
Closes #170

## What
Adds a `.npmignore` file using an allowlist approach to explicitly control which files are included when installing via `npm install github:jsturtevant/rally`.

## Why
Without a `.npmignore`, npm falls back to `.gitignore` and emits a warning:
> npm warn gitignore-fallback No .npmignore file found, using .gitignore for file exclusion.

The `.gitignore` isn't designed for package publishing — it excludes compiled JSX output that needs to ship, and includes dev files (`test/`, `docs/`, `.squad/`, `.github/`) that shouldn't.

## Published files
Only these ship in the package:
- `bin/` — CLI entry point
- `lib/` — all runtime modules
- `package.json`, `README.md`, `LICENSE`, `CHANGELOG.md`

Verified with `npm pack --dry-run` — 41 files, 34.2 kB packed.