### PR TITLE
fix: prevent premature ready-for-review status transition

### DIFF
--- a/lib/dispatch-refresh.js
+++ b/lib/dispatch-refresh.js
@@ -1,3 +1,4 @@
+import { statSync } from 'node:fs';
 import { getActiveDispatches, updateDispatchStatus } from './active.js';
 
 /**
@@ -17,19 +18,50 @@ export function isProcessRunning(pid) {
 }
 
 /**
+ * Check if a log file has been modified within the given threshold.
+ * Detached Copilot processes may still be writing to the log after the
+ * parent shell PID exits, so a recent mtime means the process is likely
+ * still active.
+ *
+ * @param {string} logPath
+ * @param {object} [opts]
+ * @param {number} [opts.thresholdMs] - Max age in ms to consider "active" (default 30 000)
+ * @param {Function} [opts._statSync] - Injectable for testing
+ * @param {Function} [opts._now] - Injectable Date.now for testing
+ * @returns {boolean}
+ */
+export function isLogFileActive(logPath, opts = {}) {
+  const threshold = opts.thresholdMs ?? 30_000;
+  const stat = opts._statSync || statSync;
+  const now = opts._now || Date.now;
+
+  if (!logPath) return false;
+
+  try {
+    const { mtimeMs } = stat(logPath);
+    return (now() - mtimeMs) < threshold;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Refresh dispatch statuses by checking whether Copilot PIDs are still alive.
- * Dispatches in "planning" or "implementing" whose PID has exited get moved to "reviewing".
+ * Dispatches in "planning" or "implementing" whose PID has exited get moved
+ * to "reviewing" only when the log file is also no longer being written to.
  *
  * @param {object} [opts]
  * @param {Function} [opts._getActiveDispatches] - Injectable for testing
  * @param {Function} [opts._updateDispatchStatus] - Injectable for testing
  * @param {Function} [opts._isProcessRunning] - Injectable for testing
+ * @param {Function} [opts._isLogFileActive] - Injectable for testing
  * @returns {object[]} List of dispatches that were updated
  */
 export function refreshDispatchStatuses(opts = {}) {
   const getDispatches = opts._getActiveDispatches || getActiveDispatches;
   const updateStatus = opts._updateDispatchStatus || updateDispatchStatus;
   const checkRunning = opts._isProcessRunning || isProcessRunning;
+  const checkLog = opts._isLogFileActive || isLogFileActive;
 
   const dispatches = getDispatches();
   const updated = [];
@@ -44,7 +76,7 @@ export function refreshDispatchStatuses(opts = {}) {
       continue;
     }
 
-    if (!checkRunning(pid)) {
+    if (!checkRunning(pid) && !checkLog(d.logPath)) {
       try {
         updateStatus(d.id, 'reviewing');
         updated.push({ ...d, status: 'reviewing' });

--- a/lib/ui/components/DispatchTable.jsx
+++ b/lib/ui/components/DispatchTable.jsx
@@ -4,7 +4,7 @@ import { formatAge } from '../dashboard-data.js';
 
 const STATUS_ICONS = {
   planning: '🔵',
-  implementing: '🟢',
+  implementing: '⏳',
   reviewing: '🟡',
   done: '✅',
   cleaned: '⚪',
@@ -16,6 +16,7 @@ function formatIssueRef(dispatch) {
 }
 
 const STATUS_LABELS = {
+  implementing: 'working',
   reviewing: 'ready for review',
 };
 

--- a/test/dispatch-refresh.test.js
+++ b/test/dispatch-refresh.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { refreshDispatchStatuses, isProcessRunning } from '../lib/dispatch-refresh.js';
+import { refreshDispatchStatuses, isProcessRunning, isLogFileActive } from '../lib/dispatch-refresh.js';
 
 describe('isProcessRunning', () => {
   test('returns true for the current process PID', () => {
@@ -13,8 +13,49 @@ describe('isProcessRunning', () => {
   });
 });
 
+describe('isLogFileActive', () => {
+  test('returns true when log file was modified recently', () => {
+    const now = 1000000;
+    const result = isLogFileActive('/tmp/test.log', {
+      _statSync: () => ({ mtimeMs: now - 5000 }),
+      _now: () => now,
+    });
+    assert.strictEqual(result, true);
+  });
+
+  test('returns false when log file is stale', () => {
+    const now = 1000000;
+    const result = isLogFileActive('/tmp/test.log', {
+      _statSync: () => ({ mtimeMs: now - 60000 }),
+      _now: () => now,
+    });
+    assert.strictEqual(result, false);
+  });
+
+  test('returns false when logPath is null', () => {
+    assert.strictEqual(isLogFileActive(null), false);
+  });
+
+  test('returns false when stat throws (file missing)', () => {
+    const result = isLogFileActive('/no/such/file', {
+      _statSync: () => { throw new Error('ENOENT'); },
+    });
+    assert.strictEqual(result, false);
+  });
+
+  test('respects custom thresholdMs', () => {
+    const now = 1000000;
+    const result = isLogFileActive('/tmp/test.log', {
+      thresholdMs: 5000,
+      _statSync: () => ({ mtimeMs: now - 10000 }),
+      _now: () => now,
+    });
+    assert.strictEqual(result, false);
+  });
+});
+
 describe('refreshDispatchStatuses', () => {
-  test('updates status to reviewing when PID is not running', () => {
+  test('updates status to reviewing when PID is not running and log is stale', () => {
     const dispatches = [
       { id: 'issue-42', status: 'planning', session_id: '99999', type: 'issue' },
     ];
@@ -24,6 +65,7 @@ describe('refreshDispatchStatuses', () => {
       _getActiveDispatches: () => dispatches,
       _updateDispatchStatus: (id, status) => { updates.push({ id, status }); },
       _isProcessRunning: () => false,
+      _isLogFileActive: () => false,
     });
 
     assert.strictEqual(updates.length, 1);
@@ -32,6 +74,23 @@ describe('refreshDispatchStatuses', () => {
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].id, 'issue-42');
     assert.strictEqual(result[0].status, 'reviewing');
+  });
+
+  test('leaves status unchanged when PID is dead but log is still active', () => {
+    const dispatches = [
+      { id: 'issue-42', status: 'implementing', session_id: '99999', type: 'issue', logPath: '/tmp/test.log' },
+    ];
+    const updates = [];
+
+    const result = refreshDispatchStatuses({
+      _getActiveDispatches: () => dispatches,
+      _updateDispatchStatus: (id, status) => { updates.push({ id, status }); },
+      _isProcessRunning: () => false,
+      _isLogFileActive: () => true,
+    });
+
+    assert.strictEqual(updates.length, 0);
+    assert.strictEqual(result.length, 0);
   });
 
   test('leaves status unchanged when PID is still running', () => {
@@ -44,6 +103,7 @@ describe('refreshDispatchStatuses', () => {
       _getActiveDispatches: () => dispatches,
       _updateDispatchStatus: (id, status) => { updates.push({ id, status }); },
       _isProcessRunning: () => true,
+      _isLogFileActive: () => false,
     });
 
     assert.strictEqual(updates.length, 0);
@@ -125,13 +185,14 @@ describe('refreshDispatchStatuses', () => {
       _getActiveDispatches: () => dispatches,
       _updateDispatchStatus: (id, status) => { updates.push({ id, status }); },
       _isProcessRunning: (pid) => runningPids.has(pid),
+      _isLogFileActive: () => false,
     });
 
     // 'a' (PID 100) still running — no update
-    // 'b' (PID 200) dead — updated
+    // 'b' (PID 200) dead, log stale — updated
     // 'c' done — skipped
     // 'd' non-PID — skipped
-    // 'e' (PID 400) dead — updated
+    // 'e' (PID 400) dead, log stale — updated
     assert.strictEqual(updates.length, 2);
     assert.strictEqual(updates[0].id, 'b');
     assert.strictEqual(updates[1].id, 'e');
@@ -152,9 +213,8 @@ describe('refreshDispatchStatuses', () => {
         if (callCount === 1) throw new Error('disk full');
       },
       _isProcessRunning: () => false,
+      _isLogFileActive: () => false,
     });
-
-    // First update throws but second succeeds
     assert.strictEqual(callCount, 2);
     assert.strictEqual(result.length, 1);
     assert.strictEqual(result[0].id, 'y');


### PR DESCRIPTION
## Problem
The dashboard was showing **🟡 ready for review** while Copilot was still actively processing (#177). The detached Copilot process (spawned with `unref()`) continues writing to the log file after the parent shell PID exits, causing the PID-only check to falsely transition status to `reviewing`.

## Fix
- Added `isLogFileActive()` — checks if the log file `mtime` is within the last 30 seconds
- `refreshDispatchStatuses()` now requires **both** PID-dead AND stale-log before transitioning to `reviewing`
- Dashboard now shows **⏳ working** for `implementing` status instead of `🟢 implementing`

## Testing
- 5 new tests for `isLogFileActive` (recent, stale, null path, missing file, custom threshold)
- 1 new test for the dual-check behavior (PID dead + log active = no transition)
- All 16 dispatch-refresh tests pass ✅

Closes #177