### PR TITLE
fix: dashboard shortcuts no longer quit unexpectedly

### DIFF
--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -3,8 +3,8 @@ import { Box, Text, useInput, useApp } from 'ink';
 import { spawn as defaultSpawn } from 'node:child_process';
 import DispatchTable from './components/DispatchTable.jsx';
 import ActionMenu, { ACTIONS } from './components/ActionMenu.jsx';
+import LogViewer from './components/LogViewer.jsx';
 import { computeSummary, getDashboardData, renderPlainDashboard } from './dashboard-data.js';
-import { dispatchLog as defaultDispatchLog } from '../dispatch-log.js';
 import { dispatchRemove as defaultDispatchRemove } from '../dispatch-remove.js';
 
 export { computeSummary, getDashboardData, renderPlainDashboard };
@@ -31,12 +31,13 @@ function SummaryLine({ summary }) {
  * Supports keyboard navigation: ↑/↓ to select, Enter to open action menu, r to refresh, q to quit.
  * Auto-refreshes at the configured interval (default 5s).
  */
-export default function Dashboard({ project, onSelect, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchLog = defaultDispatchLog, _dispatchRemove = defaultDispatchRemove }) {
+export default function Dashboard({ project, onSelect, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchRemove = defaultDispatchRemove }) {
   const { exit } = useApp();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0); // eslint-disable-line -- state setter triggers re-render to refresh data
   const [actionDispatch, setActionDispatch] = useState(null);
   const [actionIndex, setActionIndex] = useState(0);
+  const [logViewDispatch, setLogViewDispatch] = useState(null);
 
   let data;
   let error;
@@ -59,14 +60,14 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
     : [];
   const actionCount = actions.length;
 
-  // Auto-refresh at the configured interval (pause during action menu)
+  // Auto-refresh at the configured interval (pause during action menu or log view)
   useEffect(() => {
-    if (!refreshInterval || actionDispatch) return;
+    if (!refreshInterval || actionDispatch || logViewDispatch) return;
     const timer = setInterval(() => {
       setRefreshKey(k => k + 1);
     }, refreshInterval);
     return () => clearInterval(timer);
-  }, [refreshInterval, actionDispatch]);
+  }, [refreshInterval, actionDispatch, logViewDispatch]);
 
   // Clamp selectedIndex when dispatch count changes
   useEffect(() => {
@@ -86,21 +87,22 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
         console.error(`Failed to launch VS Code: ${err.message}`);
       });
     }
-    exit();
   }
 
   function viewLogs(dispatch) {
-    exit();
-    _dispatchLog(dispatch.number, { repo: dispatch.repo }).catch((err) => {
-      console.error(`Failed to view logs: ${err.message}`);
-    });
+    if (dispatch.logPath) {
+      setLogViewDispatch(dispatch);
+      setActionDispatch(null);
+      setActionIndex(0);
+    }
   }
 
   function removeSelectedDispatch(dispatch) {
-    exit();
-    _dispatchRemove(dispatch.number, { repo: dispatch.repo }).catch((err) => {
-      console.error(`Failed to remove dispatch: ${err.message}`);
-    });
+    _dispatchRemove(dispatch.number, { repo: dispatch.repo })
+      .then(() => setRefreshKey(k => k + 1))
+      .catch((err) => {
+        console.error(`Failed to remove dispatch: ${err.message}`);
+      });
   }
 
   function handleActionSelect(direction) {
@@ -131,8 +133,8 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
   }
 
   useInput((input, key) => {
-    // When action menu is open, it handles its own input
-    if (actionDispatch) return;
+    // Log view and action menu handle their own input
+    if (logViewDispatch || actionDispatch) return;
 
     if (key.upArrow) {
       setSelectedIndex(i => (i > 0 ? i - 1 : 0));
@@ -145,10 +147,7 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
     } else if (input === 'v' && count > 0) {
       openInVSCode(data.dispatches[selectedIndex]);
     } else if (input === 'l' && count > 0) {
-      const selected = data.dispatches[selectedIndex];
-      if (selected.logPath) {
-        viewLogs(selected);
-      }
+      viewLogs(data.dispatches[selectedIndex]);
     } else if (input === 'r') {
       setRefreshKey(k => k + 1);
     } else if (input === 'd' && count > 0) {
@@ -163,6 +162,15 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       <Box flexDirection="column">
         <Text color="red">✗ {error}</Text>
       </Box>
+    );
+  }
+
+  if (logViewDispatch) {
+    return (
+      <LogViewer
+        dispatch={logViewDispatch}
+        onBack={() => setLogViewDispatch(null)}
+      />
     );
   }
 

--- a/lib/ui/components/LogViewer.jsx
+++ b/lib/ui/components/LogViewer.jsx
@@ -1,0 +1,58 @@
+import React, { useState, useMemo } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { readFileSync, existsSync } from 'node:fs';
+
+/**
+ * Inline log viewer — shows .copilot-output.log content for a dispatch.
+ * ↑/↓ to scroll, Escape to return to the dashboard.
+ */
+export default function LogViewer({ dispatch, onBack, visibleLines = 20, _readFile = readFileSync, _existsSync = existsSync }) {
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  const lines = useMemo(() => {
+    if (!dispatch.logPath || !_existsSync(dispatch.logPath)) {
+      return ['No log file available.'];
+    }
+    try {
+      const content = _readFile(dispatch.logPath, 'utf8');
+      return content.split('\n');
+    } catch {
+      return ['Failed to read log file.'];
+    }
+  }, [dispatch.logPath, _readFile, _existsSync]);
+
+  const maxOffset = Math.max(0, lines.length - visibleLines);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onBack();
+    } else if (key.upArrow) {
+      setScrollOffset(o => Math.max(0, o - 1));
+    } else if (key.downArrow) {
+      setScrollOffset(o => Math.min(maxOffset, o + 1));
+    }
+  });
+
+  const visible = lines.slice(scrollOffset, scrollOffset + visibleLines);
+  const issueRef = dispatch.type === 'pr' ? `PR #${dispatch.number}` : `Issue #${dispatch.number}`;
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold>Logs for </Text>
+        <Text bold color="cyan">{issueRef}</Text>
+        <Text bold> ({dispatch.repo})</Text>
+      </Box>
+      <Box flexDirection="column">
+        {visible.map((line, i) => (
+          <Text key={scrollOffset + i} wrap="truncate">{line}</Text>
+        ))}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          ↑/↓ scroll · Esc back · Line {scrollOffset + 1}–{Math.min(scrollOffset + visibleLines, lines.length)} of {lines.length}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/test/build-jsx.mjs
+++ b/test/build-jsx.mjs
@@ -12,6 +12,7 @@ const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const jsxFiles = [
   'lib/ui/Dashboard.jsx',
   'lib/ui/components/ActionMenu.jsx',
+  'lib/ui/components/LogViewer.jsx',
   'lib/ui/components/StatusMessage.jsx',
   'lib/ui/components/DispatchBox.jsx',
   'lib/ui/components/DispatchTable.jsx',

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -318,29 +318,24 @@ describe('Dashboard component', () => {
     assert.equal(spawnArgs.cmd, 'code');
   });
 
-  it('l shortcut views logs for selected dispatch with logPath', async () => {
-    let logCalled = false;
-    let logNumber;
-    const mockDispatchLog = async (number, opts) => {
-      logCalled = true;
-      logNumber = number;
-    };
-
+  it('l shortcut shows inline log viewer for selected dispatch with logPath', async () => {
     const dispatches = makeSampleDispatches();
     dispatches[0].logPath = '/tmp/test-log.txt';
+    writeFileSync(dispatches[0].logPath, 'line1\nline2\nline3', 'utf8');
     writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
 
     instance = render(
       React.createElement(Dashboard, {
         refreshInterval: 0,
-        _dispatchLog: mockDispatchLog,
       })
     );
     await delay();
     instance.stdin.write('l');
     await delay();
-    assert.ok(logCalled, 'l shortcut should call dispatchLog');
-    assert.equal(logNumber, 42, 'should pass dispatch number');
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Logs for'), 'should show log viewer title');
+    assert.ok(output.includes('Issue #42'), 'should show dispatch ref');
+    assert.ok(output.includes('Esc back'), 'should show escape hint');
   });
 
   it('l shortcut does nothing when no logPath', async () => {
@@ -381,22 +376,15 @@ describe('Dashboard component', () => {
     assert.equal(removeNumber, 42, 'should pass dispatch number');
   });
 
-  it('action menu View logs calls dispatchLog', async () => {
-    let logCalled = false;
-    let logNumber;
-    const mockDispatchLog = async (number, opts) => {
-      logCalled = true;
-      logNumber = number;
-    };
-
+  it('action menu View logs opens inline log viewer', async () => {
     const dispatches = makeSampleDispatches();
     dispatches[0].logPath = '/tmp/test-log.txt';
+    writeFileSync(dispatches[0].logPath, 'action-log-line', 'utf8');
     writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
 
     instance = render(
       React.createElement(Dashboard, {
         refreshInterval: 0,
-        _dispatchLog: mockDispatchLog,
       })
     );
     await delay();
@@ -406,7 +394,63 @@ describe('Dashboard component', () => {
     await delay();
     instance.stdin.write('\r');
     await delay();
-    assert.ok(logCalled, 'should have called dispatchLog');
-    assert.equal(logNumber, 42, 'should pass dispatch number');
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Logs for'), 'should show log viewer');
+    assert.ok(output.includes('Issue #42'), 'should show dispatch ref');
+  });
+
+  it('log viewer Escape returns to dashboard', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].logPath = '/tmp/test-log.txt';
+    writeFileSync(dispatches[0].logPath, 'escape-test-log', 'utf8');
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0 })
+    );
+    await delay();
+    instance.stdin.write('l');
+    await delay();
+    assert.ok(instance.lastFrame().includes('Logs for'), 'should show log viewer');
+    instance.stdin.write('\x1B');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Rally Dashboard'), 'Escape should return to dashboard');
+  });
+
+  it('v shortcut does not quit the dashboard', async () => {
+    let spawnCalled = false;
+    const spawnMock = (cmd, args) => {
+      spawnCalled = true;
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    instance.stdin.write('v');
+    await delay();
+    assert.ok(spawnCalled, 'should have called spawn');
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Rally Dashboard'), 'dashboard should still be visible after v');
+  });
+
+  it('d shortcut does not quit the dashboard', async () => {
+    let removeCalled = false;
+    const mockDispatchRemove = async (number) => { removeCalled = true; };
+
+    instance = render(
+      React.createElement(Dashboard, {
+        refreshInterval: 0,
+        _dispatchRemove: mockDispatchRemove,
+      })
+    );
+    await delay();
+    instance.stdin.write('d');
+    await delay();
+    assert.ok(removeCalled, 'd should call dispatchRemove');
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Rally Dashboard'), 'dashboard should still be visible after d');
   });
 });


### PR DESCRIPTION
Closes #172

## Problem
Pressing `l` (logs) or `v` (VS Code) on the dashboard quit the entire app. Users had to re-run the command to get back.

## Fix
- **`v` (VS Code):** Spawns `code` detached and stays on the dashboard
- **`l` (logs):** Opens a new inline `LogViewer` component showing the dispatch's `.copilot-output.log` content. Press Escape to return to the dispatch table.
- **`d` (delete):** Removes the dispatch and refreshes in place instead of quitting
- **Rule:** Only `q` exits the dashboard

## New component
`lib/ui/components/LogViewer.jsx` — scrollable log viewer with ↑/↓ navigation and Escape to return.

## Tests
3 new tests added, 2 existing tests updated. All 47 tests pass.