### PR TITLE
feat: add onboard remove command

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -31,7 +31,7 @@ program
     }
   });
 
-program
+const onboardCmd = program
   .command('onboard')
   .description('Onboard a repo to Rally (local path, GitHub URL, or owner/repo)')
   .argument('[path]', 'Path, GitHub URL, or owner/repo (defaults to current directory)')
@@ -40,6 +40,20 @@ program
   .action(async (pathArg, opts) => {
     try {
       await onboard({ path: pathArg, team: opts.team });
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+onboardCmd
+  .command('remove')
+  .description('Remove an onboarded project from Rally')
+  .argument('[project]', 'Project name to remove (interactive picker if omitted)')
+  .option('--yes', 'Skip confirmation prompt')
+  .action(async (project, opts) => {
+    try {
+      const { onboardRemove } = await import('../lib/onboard-remove.js');
+      await onboardRemove({ project, yes: opts.yes });
     } catch (err) {
       handleError(err);
     }

--- a/lib/onboard-remove.js
+++ b/lib/onboard-remove.js
@@ -1,0 +1,113 @@
+import { existsSync, lstatSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import chalk from 'chalk';
+import { readProjects, writeProjects } from './config.js';
+import { removeSymlink } from './symlink.js';
+import { removeExcludes, getExcludeEntries } from './exclude.js';
+
+/**
+ * Remove an onboarded project from Rally.
+ * Removes the project entry from projects.yaml, cleans up symlinks,
+ * and removes exclude entries from .git/info/exclude.
+ *
+ * @param {object} [options]
+ * @param {string} [options.project] - Project name to remove (interactive picker if omitted)
+ * @param {boolean} [options.yes] - Skip confirmation prompt
+ * @param {Function} [options._select] - Injectable select function (for testing)
+ * @param {Function} [options._confirm] - Injectable confirm function (for testing)
+ * @param {Function} [options._readProjects] - Injectable for testing
+ * @param {Function} [options._writeProjects] - Injectable for testing
+ * @param {object} [options._chalk] - Injectable for testing
+ * @returns {Promise<object>} The removed project entry
+ */
+export async function onboardRemove(options = {}) {
+  const _readProjects = options._readProjects || readProjects;
+  const _writeProjects = options._writeProjects || writeProjects;
+  const _chalk = options._chalk || chalk;
+
+  const projects = _readProjects();
+  const projectList = projects.projects || [];
+
+  if (projectList.length === 0) {
+    throw new Error('No onboarded projects found.');
+  }
+
+  let project;
+
+  if (options.project) {
+    // Find by name or repo
+    project = projectList.find(
+      (p) => p.name === options.project || p.repo === options.project
+    );
+    if (!project) {
+      throw new Error(
+        `Project "${options.project}" not found. Run ${_chalk.dim('rally onboard remove')} to see available projects.`
+      );
+    }
+  } else {
+    // Interactive picker
+    const selectFn = options._select || (await import('@inquirer/prompts')).select;
+    const choices = projectList.map((p) => ({
+      name: `${p.name}${p.repo ? ` (${p.repo})` : ''} — ${p.path}`,
+      value: p.name,
+    }));
+    const selected = await selectFn({
+      message: 'Select a project to remove:',
+      choices,
+    });
+    project = projectList.find((p) => p.name === selected);
+  }
+
+  // Confirm removal
+  if (!options.yes) {
+    const confirmFn = options._confirm || (await import('@inquirer/prompts')).confirm;
+    const confirmed = await confirmFn({
+      message: `Remove "${project.name}"${project.repo ? ` (${project.repo})` : ''} from Rally?`,
+      default: false,
+    });
+    if (!confirmed) {
+      console.log(_chalk.dim('Cancelled.'));
+      return null;
+    }
+  }
+
+  // Clean up symlinks if project path still exists
+  const projectPath = project.path;
+  if (projectPath && existsSync(projectPath)) {
+    const symlinks = [
+      join(projectPath, '.squad'),
+      join(projectPath, '.squad-templates'),
+      join(projectPath, '.github', 'agents', 'squad.agent.md'),
+    ];
+    for (const linkPath of symlinks) {
+      try {
+        if (existsSync(linkPath) || lstatSync(linkPath).isSymbolicLink()) {
+          removeSymlink(linkPath);
+        }
+      } catch {
+        // Symlink may already be gone
+      }
+    }
+
+    // Remove exclude entries from .git/info/exclude
+    const gitDir = join(projectPath, '.git');
+    if (existsSync(gitDir)) {
+      try {
+        const excludeEntries = getExcludeEntries();
+        const allExcludes = [...excludeEntries, '.worktrees/', '.worktrees'];
+        removeExcludes(gitDir, allExcludes);
+      } catch {
+        // Best effort — exclude file may not exist
+      }
+    }
+  }
+
+  // Remove from projects.yaml
+  projects.projects = projectList.filter((p) => p.name !== project.name);
+  _writeProjects(projects);
+
+  console.log(
+    _chalk.green('✓') + ` Removed project: ${project.name}${project.repo ? ` (${project.repo})` : ''}`
+  );
+  return project;
+}

--- a/test/onboard-remove.test.js
+++ b/test/onboard-remove.test.js
@@ -1,0 +1,256 @@
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync, rmSync, existsSync, readFileSync,
+  mkdirSync, writeFileSync, symlinkSync, lstatSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import yaml from 'js-yaml';
+import { onboardRemove } from '../lib/onboard-remove.js';
+
+describe('onboard remove', () => {
+  let tempDir;
+  let originalEnv;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'rally-onboard-remove-test-'));
+    originalEnv = process.env.RALLY_HOME;
+    process.env.RALLY_HOME = join(tempDir, 'rally-home');
+    mkdirSync(process.env.RALLY_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalEnv) {
+      process.env.RALLY_HOME = originalEnv;
+    } else {
+      delete process.env.RALLY_HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const silentChalk = {
+    green: (s) => s,
+    red: (s) => s,
+    yellow: (s) => s,
+    dim: (s) => s,
+  };
+
+  function createRepo(repoPath) {
+    mkdirSync(repoPath, { recursive: true });
+    execFileSync('git', ['init', repoPath], { stdio: 'ignore' });
+    return repoPath;
+  }
+
+  function writeProjectsYaml(projects) {
+    const projectsPath = join(process.env.RALLY_HOME, 'projects.yaml');
+    writeFileSync(projectsPath, yaml.dump({ projects }), 'utf8');
+  }
+
+  function readProjectsYaml() {
+    const projectsPath = join(process.env.RALLY_HOME, 'projects.yaml');
+    return yaml.load(readFileSync(projectsPath, 'utf8'));
+  }
+
+  function setupOnboardedProject(name, repoPath, extra = {}) {
+    const teamDir = join(tempDir, 'team');
+    mkdirSync(join(teamDir, '.squad'), { recursive: true });
+    mkdirSync(join(teamDir, '.squad-templates'), { recursive: true });
+
+    // Create symlinks in the project
+    symlinkSync(join(teamDir, '.squad'), join(repoPath, '.squad'));
+    symlinkSync(join(teamDir, '.squad-templates'), join(repoPath, '.squad-templates'));
+
+    return {
+      name,
+      repo: `owner/${name}`,
+      path: repoPath,
+      team: 'shared',
+      teamDir,
+      onboarded: new Date().toISOString(),
+      ...extra,
+    };
+  }
+
+  // --- Removes project from projects.yaml ---
+
+  test('removes specified project from projects.yaml', async () => {
+    const repoPath = createRepo(join(tempDir, 'my-repo'));
+    const entry = setupOnboardedProject('my-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    const result = await onboardRemove({
+      project: 'my-repo',
+      yes: true,
+      _chalk: silentChalk,
+    });
+
+    assert.strictEqual(result.name, 'my-repo');
+    const data = readProjectsYaml();
+    assert.strictEqual(data.projects.length, 0);
+  });
+
+  test('removes project matched by repo name (owner/repo)', async () => {
+    const repoPath = createRepo(join(tempDir, 'my-repo'));
+    const entry = setupOnboardedProject('my-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    const result = await onboardRemove({
+      project: 'owner/my-repo',
+      yes: true,
+      _chalk: silentChalk,
+    });
+
+    assert.strictEqual(result.name, 'my-repo');
+    const data = readProjectsYaml();
+    assert.strictEqual(data.projects.length, 0);
+  });
+
+  // --- Keeps other projects intact ---
+
+  test('only removes the specified project, keeps others', async () => {
+    const repo1 = createRepo(join(tempDir, 'repo-a'));
+    const repo2 = createRepo(join(tempDir, 'repo-b'));
+    const entry1 = setupOnboardedProject('repo-a', repo1);
+    const entry2 = setupOnboardedProject('repo-b', repo2);
+    writeProjectsYaml([entry1, entry2]);
+
+    await onboardRemove({
+      project: 'repo-a',
+      yes: true,
+      _chalk: silentChalk,
+    });
+
+    const data = readProjectsYaml();
+    assert.strictEqual(data.projects.length, 1);
+    assert.strictEqual(data.projects[0].name, 'repo-b');
+  });
+
+  // --- Cleans up symlinks ---
+
+  test('removes symlinks from project directory', async () => {
+    const repoPath = createRepo(join(tempDir, 'my-repo'));
+    const entry = setupOnboardedProject('my-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    assert.ok(existsSync(join(repoPath, '.squad')), '.squad should exist before removal');
+
+    await onboardRemove({
+      project: 'my-repo',
+      yes: true,
+      _chalk: silentChalk,
+    });
+
+    // lstatSync won't throw because the symlink itself is gone
+    assert.ok(!existsSync(join(repoPath, '.squad')), '.squad should be removed');
+    assert.ok(!existsSync(join(repoPath, '.squad-templates')), '.squad-templates should be removed');
+  });
+
+  // --- Error: project not found ---
+
+  test('throws when project name not found', async () => {
+    const repoPath = createRepo(join(tempDir, 'other-repo'));
+    const entry = setupOnboardedProject('other-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    await assert.rejects(
+      () => onboardRemove({ project: 'nonexistent', yes: true, _chalk: silentChalk }),
+      /not found/
+    );
+  });
+
+  // --- Error: no onboarded projects ---
+
+  test('throws when no projects are onboarded', async () => {
+    writeProjectsYaml([]);
+
+    await assert.rejects(
+      () => onboardRemove({ _chalk: silentChalk }),
+      /No onboarded projects found/
+    );
+  });
+
+  // --- Confirmation: cancelled ---
+
+  test('returns null when user cancels confirmation', async () => {
+    const repoPath = createRepo(join(tempDir, 'my-repo'));
+    const entry = setupOnboardedProject('my-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    const result = await onboardRemove({
+      project: 'my-repo',
+      _confirm: async () => false,
+      _chalk: silentChalk,
+    });
+
+    assert.strictEqual(result, null);
+    const data = readProjectsYaml();
+    assert.strictEqual(data.projects.length, 1, 'project should still exist');
+  });
+
+  // --- Confirmation: --yes skips prompt ---
+
+  test('--yes skips confirmation prompt', async () => {
+    const repoPath = createRepo(join(tempDir, 'my-repo'));
+    const entry = setupOnboardedProject('my-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    // If _confirm were called without --yes, it would reject
+    const result = await onboardRemove({
+      project: 'my-repo',
+      yes: true,
+      _confirm: async () => { throw new Error('should not be called'); },
+      _chalk: silentChalk,
+    });
+
+    assert.strictEqual(result.name, 'my-repo');
+  });
+
+  // --- Interactive picker ---
+
+  test('uses interactive picker when no project name given', async () => {
+    const repoPath = createRepo(join(tempDir, 'my-repo'));
+    const entry = setupOnboardedProject('my-repo', repoPath);
+    writeProjectsYaml([entry]);
+
+    let selectCalled = false;
+    const mockSelect = async ({ choices }) => {
+      selectCalled = true;
+      assert.ok(choices.length > 0, 'should have choices');
+      return choices[0].value;
+    };
+
+    const result = await onboardRemove({
+      _select: mockSelect,
+      _confirm: async () => true,
+      _chalk: silentChalk,
+    });
+
+    assert.ok(selectCalled, 'select should have been called');
+    assert.strictEqual(result.name, 'my-repo');
+  });
+
+  // --- Handles missing project path gracefully ---
+
+  test('succeeds even if project path no longer exists', async () => {
+    const fakePath = join(tempDir, 'gone-repo');
+    writeProjectsYaml([{
+      name: 'gone-repo',
+      repo: 'owner/gone-repo',
+      path: fakePath,
+      team: 'shared',
+      onboarded: new Date().toISOString(),
+    }]);
+
+    const result = await onboardRemove({
+      project: 'gone-repo',
+      yes: true,
+      _chalk: silentChalk,
+    });
+
+    assert.strictEqual(result.name, 'gone-repo');
+    const data = readProjectsYaml();
+    assert.strictEqual(data.projects.length, 0);
+  });
+});


### PR DESCRIPTION
Closes #178

## What
Adds `rally onboard remove [project]` subcommand so users can remove projects that were onboarded via CLI.

## How it works
- `rally onboard remove` — interactive picker lists all onboarded projects
- `rally onboard remove my-project` — removes by name or owner/repo
- Confirms before removing (skip with `--yes`)
- Cleans up symlinks (`.squad`, `.squad-templates`, `.github/agents/squad.agent.md`)
- Removes `.git/info/exclude` entries
- Removes project from `projects.yaml`

## Testing
10 new tests covering: removal, symlink cleanup, confirmation flow, interactive picker, missing paths, error cases.

All 404 tests pass.