### PR TITLE
ci: add concurrency group to cancel duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adds a concurrency group to the CI workflow that automatically cancels in-progress runs when new commits are pushed to the same ref. This prevents wasted CI resources from duplicate workflow runs.

The concurrency group is based on workflow name + git ref, so different PRs won't interfere with each other.

Closes #197