### PR TITLE
refactor: fatal() throws RallyError instead of process.exit

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -6,7 +6,7 @@ import { Command } from 'commander';
 import { setup } from '../lib/setup.js';
 import { onboard } from '../lib/onboard.js';
 import { getStatus, formatStatus } from '../lib/status.js';
-import { handleError } from '../lib/errors.js';
+import { handleError, RallyError } from '../lib/errors.js';
 import { assertTools } from '../lib/tools.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -312,4 +312,12 @@ dispatch
     }
   });
 
-program.parse();
+try {
+  program.parse();
+} catch (err) {
+  if (err instanceof RallyError) {
+    console.error(`Error: ${err.message}`);
+    process.exit(err.exitCode);
+  }
+  throw err;
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,14 +12,13 @@ export class RallyError extends Error {
   }
 }
 
-export function fatal(message, exitCode = EXIT_GENERAL, opts = {}) {
-  const _console = opts._console || console;
-  const _process = opts._process || process;
-  _console.error(`Error: ${message}`);
-  _process.exit(exitCode);
+export function fatal(message, exitCode = EXIT_GENERAL) {
+  throw new RallyError(message, exitCode);
 }
 
-export function handleError(err, opts = {}) {
-  const exitCode = err instanceof RallyError ? err.exitCode : EXIT_GENERAL;
-  fatal(err.message, exitCode, opts);
+export function handleError(err) {
+  if (err instanceof RallyError) {
+    throw err;
+  }
+  throw new RallyError(err.message, EXIT_GENERAL);
 }

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -31,30 +31,28 @@ describe('exit code constants', () => {
 });
 
 describe('fatal()', () => {
-  it('calls process.exit with the given code', () => {
-    const f = makeFakes();
-    fatal('boom', 3, f);
-    assert.deepEqual(f.exits, [3]);
+  it('throws RallyError with the given exit code', () => {
+    assert.throws(
+      () => fatal('boom', 3),
+      (err) => err instanceof RallyError && err.exitCode === 3 && err.message === 'boom'
+    );
   });
 
   it('defaults to exit code 1', () => {
-    const f = makeFakes();
-    fatal('boom', undefined, f);
-    assert.deepEqual(f.exits, [1]);
+    assert.throws(
+      () => fatal('boom'),
+      (err) => err instanceof RallyError && err.exitCode === 1
+    );
   });
 
-  it('logs message to stderr', () => {
-    const f = makeFakes();
-    fatal('something broke', 1, f);
-    assert.deepEqual(f.logs, ['Error: something broke']);
-  });
-
-  it('does not log stack traces', () => {
-    const f = makeFakes();
-    fatal('oops', 1, f);
-    for (const line of f.logs) {
-      assert.ok(!line.includes('at '), 'should not contain stack trace');
-      assert.ok(!line.includes('Error\n'), 'should not contain raw Error');
+  it('creates error with message', () => {
+    try {
+      fatal('something broke', 1);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.ok(err instanceof RallyError);
+      assert.equal(err.message, 'something broke');
+      assert.equal(err.exitCode, 1);
     }
   });
 });
@@ -78,17 +76,21 @@ describe('RallyError', () => {
 });
 
 describe('handleError()', () => {
-  it('maps RallyError to its exitCode', () => {
-    const f = makeFakes();
-    handleError(new RallyError('git fail', EXIT_GIT), f);
-    assert.deepEqual(f.exits, [EXIT_GIT]);
-    assert.deepEqual(f.logs, ['Error: git fail']);
+  it('throws RallyError if given RallyError', () => {
+    const err = new RallyError('git fail', EXIT_GIT);
+    assert.throws(
+      () => handleError(err),
+      (thrown) => thrown === err && thrown.exitCode === EXIT_GIT
+    );
   });
 
-  it('maps generic Error to EXIT_GENERAL', () => {
-    const f = makeFakes();
-    handleError(new Error('unknown'), f);
-    assert.deepEqual(f.exits, [EXIT_GENERAL]);
-    assert.deepEqual(f.logs, ['Error: unknown']);
+  it('wraps generic Error in RallyError with EXIT_GENERAL', () => {
+    const err = new Error('unknown');
+    assert.throws(
+      () => handleError(err),
+      (thrown) => thrown instanceof RallyError && 
+                  thrown.exitCode === EXIT_GENERAL && 
+                  thrown.message === 'unknown'
+    );
   });
 });


### PR DESCRIPTION
Closes #196

## Summary
Library code should not terminate the process. This PR refactors `fatal()` and `handleError()` to throw `RallyError` instead of calling `process.exit()`, with the CLI entry point (`bin/rally.js`) handling the error and exiting appropriately.

## Changes
- **lib/errors.js**: `fatal()` now throws `RallyError` instead of calling `process.exit()`
- **lib/errors.js**: `handleError()` now throws instead of calling `fatal()`
- **bin/rally.js**: Added top-level error handler to catch `RallyError` and call `process.exit()` with the appropriate exit code
- **test/errors.test.js**: Updated tests to verify the new throwing behavior

## Testing
- All existing tests pass
- Error tests verify that `fatal()` and `handleError()` throw `RallyError`
- CLI still works correctly with `--version` flag

## Breaking Changes
None for external callers. The `fatal()` function signature changed to remove the `opts` parameter (which was only used for testing), but callers don't need to change since they weren't using it.