### PR TITLE
fix: detect and recover from stale active.yaml locks

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -17,6 +17,9 @@ function isPidAlive(pid) {
     process.kill(pid, 0);
     return true;
   } catch (err) {
+    // EPERM means the process exists but we lack permissions to signal it.
+    // For lock ownership, treat this as "alive" to avoid removing locks held by privileged processes.
+    // Note: dispatch-refresh.js returns false on EPERM because it only cares about processes we can monitor.
     return err.code === 'EPERM';
   }
 }
@@ -28,10 +31,10 @@ function readLockInfo(lockDir) {
     const raw = readFileSync(infoPath, 'utf8');
     const info = JSON.parse(raw);
     if (!info || typeof info !== 'object') return null;
-    return {
-      pid: Number.isFinite(info.pid) ? info.pid : Number.parseInt(info.pid, 10),
-      timestamp: Number.isFinite(info.timestamp) ? info.timestamp : Number.parseInt(info.timestamp, 10),
-    };
+    const pid = Number.isFinite(info.pid) ? info.pid : Number.parseInt(info.pid, 10);
+    const timestamp = Number.isFinite(info.timestamp) ? info.timestamp : Number.parseInt(info.timestamp, 10);
+    if (!Number.isFinite(pid) || !Number.isFinite(timestamp)) return null;
+    return { pid, timestamp };
   } catch {
     return null;
   }
@@ -111,6 +114,7 @@ function acquireLock() {
           continue;
         } catch (cleanupErr) {
           console.error(`Warning: failed to cleanup stale lock at ${lockDir}: ${cleanupErr.message}`);
+          continue;
         }
       }
       // Use Atomics.wait for proper sleep without CPU spin
@@ -119,9 +123,10 @@ function acquireLock() {
     }
   }
   const pidInfo = lastAlivePid ? ` (PID ${lastAlivePid})` : '';
+  const staleMinutes = Math.ceil(LOCK_STALE_MS / 60000);
   throw new Error(
     `Failed to acquire lock on active.yaml — another rally process${pidInfo} is running. ` +
-    `If this is stale, remove ${lockDir} or wait 5 minutes and retry.`
+    `If this is stale, remove ${lockDir} or wait ${staleMinutes} minutes and retry.`
   );
 }
 

--- a/test/active.test.js
+++ b/test/active.test.js
@@ -1,6 +1,6 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, utimesSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -206,7 +206,7 @@ test('lock is released even when wrapped function throws', () => {
 test('stale lock by age is removed and addDispatch succeeds', () => {
   const lockDir = join(tempDir, '.active.lock');
   mkdirSync(lockDir);
-  const staleInfo = { pid: process.pid, timestamp: Date.now() - 6 * 60 * 1000 };
+  const staleInfo = { pid: 999999, timestamp: Date.now() - 6 * 60 * 1000 };
   writeFileSync(join(lockDir, 'info.json'), JSON.stringify(staleInfo), 'utf8');
 
   const result = addDispatch(makeRecord({ id: 'stale-age' }));
@@ -223,6 +223,36 @@ test('stale lock by dead pid is removed and addDispatch succeeds', () => {
   const result = addDispatch(makeRecord({ id: 'stale-pid' }));
   assert.strictEqual(result.id, 'stale-pid');
   assert.ok(!existsSync(lockDir), 'stale lock dir should be removed');
+});
+
+test('lock without info.json (legacy) uses mtime for stale detection', () => {
+  const lockDir = join(tempDir, '.active.lock');
+  mkdirSync(lockDir);
+  // Create lock dir but no info.json — simulate legacy or failed write
+  // Touch the dir to set mtime to 6 minutes ago
+  const staleTime = Date.now() - 6 * 60 * 1000;
+  utimesSync(lockDir, new Date(staleTime), new Date(staleTime));
+
+  const result = addDispatch(makeRecord({ id: 'legacy-lock' }));
+  assert.strictEqual(result.id, 'legacy-lock');
+  assert.ok(!existsSync(lockDir), 'legacy lock dir should be removed by mtime');
+});
+
+test('non-stale lock (alive PID, recent timestamp) is NOT removed', () => {
+  const lockDir = join(tempDir, '.active.lock');
+  mkdirSync(lockDir);
+  const validInfo = { pid: process.pid, timestamp: Date.now() };
+  writeFileSync(join(lockDir, 'info.json'), JSON.stringify(validInfo), 'utf8');
+
+  // Attempt to add dispatch should timeout waiting for this valid lock
+  const startTime = Date.now();
+  assert.throws(
+    () => addDispatch(makeRecord({ id: 'should-fail' })),
+    /Failed to acquire lock/
+  );
+  const elapsed = Date.now() - startTime;
+  assert.ok(elapsed >= 10000, 'should wait for lock timeout');
+  assert.ok(existsSync(lockDir), 'valid lock dir should NOT be removed');
 });
 
 test('updateDispatchField updates a single field', () => {


### PR DESCRIPTION
## Summary
- write PID/timestamp lock info and detect stale active.yaml locks
- auto-clean stale locks and improve lock acquisition error guidance
- add stale lock recovery tests

## Testing
- node --test (fails: e2e tests timed out: rally status --json, dispatch clean removes done dispatches, dispatch clean skips when no done dispatches)