### PR TITLE
fix: dashboard renders in fullscreen mode

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -99,7 +99,7 @@ const dashboard = program
         const React = await import('react');
         const { render } = await import('ink');
         const { default: Dashboard } = await import('../lib/ui/Dashboard.js');
-        render(React.createElement(Dashboard, { project: opts.project }));
+        render(React.createElement(Dashboard, { project: opts.project }), { fullScreen: true });
       }
     } catch (err) {
       handleError(err);

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Text, useInput, useApp } from 'ink';
+import { Box, Text, useInput, useApp, useStdout } from 'ink';
 import { spawn as defaultSpawn } from 'node:child_process';
 import DispatchTable from './components/DispatchTable.jsx';
 import ActionMenu, { ACTIONS } from './components/ActionMenu.jsx';
@@ -34,6 +34,7 @@ function SummaryLine({ summary }) {
  */
 export default function Dashboard({ project, onSelect, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchRemove = defaultDispatchRemove }) {
   const { exit } = useApp();
+  const { stdout } = useStdout();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [refreshKey, setRefreshKey] = useState(0); // eslint-disable-line -- state setter triggers re-render to refresh data
   const [actionDispatch, setActionDispatch] = useState(null);
@@ -199,7 +200,7 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
   }
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" height={stdout.rows}>
       <Box marginBottom={1}>
         <Text bold>Rally Dashboard</Text>
       </Box>


### PR DESCRIPTION
Passes `fullScreen: true` to Ink's `render()` so the rally dashboard uses the entire terminal window instead of rendering in a small region. Also sets the outer `<Box>` height to `stdout.rows` via `useStdout()` so the layout fills the terminal.

Closes #212