### PR TITLE
feat: Connect IDE session action for dashboard

### DIFF
--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -1,6 +1,9 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { openSync, closeSync, readFileSync, existsSync } from 'node:fs';
 
+/** UUID v4 regex pattern for validating Copilot session IDs. */
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Tools denied during dispatch to enforce read-only mode.
  * Deny flags take precedence over --allow-all-tools.

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -7,7 +7,7 @@ import LogViewer from './components/LogViewer.jsx';
 import DetailView from './components/DetailView.jsx';
 import { computeSummary, getDashboardData, renderPlainDashboard } from './dashboard-data.js';
 import { dispatchRemove as defaultDispatchRemove } from '../dispatch-remove.js';
-import { parseSessionIdFromLog as defaultParseSessionId } from '../copilot.js';
+import { parseSessionIdFromLog as defaultParseSessionId, UUID_RE } from '../copilot.js';
 
 export { computeSummary, getDashboardData, renderPlainDashboard };
 
@@ -56,7 +56,7 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
 
   // A session ID is connectable if it looks like a UUID (not a PID or 'pending')
   const hasConnectableSession = actionDispatch?.session_id &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(actionDispatch.session_id);
+    UUID_RE.test(actionDispatch.session_id);
 
   // Derive the action list once — used for both count and selection
   const actions = actionDispatch
@@ -113,11 +113,13 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
     // Open VS Code at the worktree path
     const codeChild = _spawn('code', [worktreePath], { detached: true, stdio: 'ignore' });
     codeChild.unref();
-    codeChild.on('error', () => {});
+    codeChild.on('error', (err) => {
+      console.error(`Failed to launch VS Code: ${err.message}`);
+    });
 
-    // Bridge the session to VS Code via copilot --resume + /ide
-    const copilotChild = _spawn('copilot', [
-      '--resume', sessionId,
+    // Bridge the session to VS Code via gh copilot --resume + /ide
+    const copilotChild = _spawn('gh', [
+      'copilot', '--resume', sessionId,
       '-p', '/ide',
       '--allow-all',
     ], {
@@ -126,7 +128,9 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       stdio: 'ignore',
     });
     copilotChild.unref();
-    copilotChild.on('error', () => {});
+    copilotChild.on('error', (err) => {
+      console.error(`Failed to launch copilot session bridge: ${err.message}`);
+    });
   }
 
   function viewLogs(dispatch) {
@@ -193,7 +197,10 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
     } else if (input === 'v' && count > 0) {
       openInVSCode(data.dispatches[selectedIndex]);
     } else if (input === 'c' && count > 0) {
-      connectIDE(data.dispatches[selectedIndex]);
+      const selected = data.dispatches[selectedIndex];
+      if (selected.session_id && UUID_RE.test(selected.session_id)) {
+        connectIDE(selected);
+      }
     } else if (input === 'l' && count > 0) {
       viewLogs(data.dispatches[selectedIndex]);
     } else if (input === 'r') {

--- a/lib/ui/components/ActionMenu.jsx
+++ b/lib/ui/components/ActionMenu.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Text, useInput } from 'ink';
+import { UUID_RE } from '../../copilot.js';
 
 const ACTIONS = {
   OPEN_VSCODE: 'open-vscode',
@@ -15,7 +16,7 @@ const ACTIONS = {
 export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack }) {
   const hasLog = Boolean(dispatch.logPath);
   const hasConnectableSession = dispatch.session_id &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(dispatch.session_id);
+    UUID_RE.test(dispatch.session_id);
 
   const actions = [
     { id: ACTIONS.OPEN_VSCODE, label: '(v) Open in VS Code' },

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -500,4 +500,79 @@ describe('Dashboard component', () => {
     const output = instance.lastFrame();
     assert.ok(output.includes('Rally Dashboard'), 'dashboard should still be visible after x');
   });
+
+  it('c shortcut spawns both code and gh copilot when session is a UUID', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].session_id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    const spawnedCmds = [];
+    const spawnMock = (cmd, args, opts) => {
+      spawnedCmds.push({ cmd, args });
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    instance.stdin.write('c');
+    await delay();
+    assert.equal(spawnedCmds.length, 2, 'should spawn two processes');
+    assert.equal(spawnedCmds[0].cmd, 'code', 'first spawn should be VS Code');
+    assert.equal(spawnedCmds[1].cmd, 'gh', 'second spawn should be gh');
+    assert.ok(spawnedCmds[1].args.includes('copilot'), 'should include copilot arg');
+    assert.ok(spawnedCmds[1].args.includes('--resume'), 'should include --resume arg');
+    assert.ok(spawnedCmds[1].args.includes('a1b2c3d4-e5f6-7890-abcd-ef1234567890'), 'should include session ID');
+  });
+
+  it('c shortcut does nothing when session is not a UUID', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].session_id = '12345'; // PID, not UUID
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    let spawnCalled = false;
+    const spawnMock = () => {
+      spawnCalled = true;
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    instance.stdin.write('c');
+    await delay();
+    assert.ok(!spawnCalled, 'should not spawn when session is a PID');
+  });
+
+  it('action menu shows Connect IDE only when session is a UUID', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].session_id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0 })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Connect IDE session'), 'should show Connect IDE for UUID session');
+  });
+
+  it('action menu hides Connect IDE when session is not a UUID', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].session_id = 'not-a-uuid';
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0 })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(!output.includes('Connect IDE session'), 'should not show Connect IDE for non-UUID session');
+  });
 });


### PR DESCRIPTION
## Summary

Adds a new **Connect IDE session** action to the Rally dashboard that uses the Copilot CLI's `/ide` command to properly bridge a CLI agent session to VS Code.

### Problem (#214)
When pressing `v` to open VS Code from the dashboard, the Copilot session files contain event types (`session.plan_changed`) that VS Code's Copilot extension doesn't understand, causing a "Session file is corrupted" error.

### Solution (Option B)
Instead of just opening `code [path]`, the new **Connect IDE** action (`c` shortcut):
1. Opens VS Code at the worktree path
2. Runs `copilot --resume <session-id> -p "/ide" --allow-all` as a background process

The `/ide` command is designed for session bridging between CLI and IDE — it uses a proper protocol handoff instead of having VS Code parse raw CLI session files.

### How to test
1. Have an active dispatch with a completed Copilot session (UUID session ID)
2. Open the dashboard: `rally dashboard`
3. Press `c` on a dispatch (or Enter → select 'Connect IDE session')
4. Verify VS Code opens AND the Copilot session connects properly

### Details
- The action only appears when a valid UUID session ID is available
- Falls back to parsing session ID from log file if stored value is a PID
- Existing `v` (Open in VS Code) behavior is unchanged
- All 29 Dashboard tests pass

@jsturtevant Please pull and test — this is experimental. The key question is whether `copilot --resume <session-id> -p "/ide"` properly bridges the session to VS Code in non-interactive mode.

Refs #214