### PR TITLE
fix: use upstream repo for fork issue/PR fetching

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { readProjects } from './config.js';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 /**
  * Parse owner/repo from a --repo flag value.
@@ -65,10 +66,15 @@ export function getRemoteRepo(projectPath, opts = {}) {
  */
 function resolveProjectRepo(project, _exec) {
   if (project.repo) {
-    const parts = project.repo.split('/');
+    const trimmed = project.repo.trim();
+    const parts = trimmed.split('/');
     if (parts.length === 2 && parts[0] && parts[1]) {
       return { owner: parts[0], repo: parts[1] };
     }
+    throw new RallyError(
+      `Invalid repo format "${project.repo}" in projects.yaml for project "${project.name || project.path}". Expected "owner/repo".`,
+      EXIT_GENERAL
+    );
   }
   return getRemoteRepo(project.path, { _exec });
 }

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -306,7 +306,8 @@ describe('resolveRepo', () => {
 
   test('cwd detection uses project.repo (upstream) instead of git remote for fork projects', () => {
     const repoPath = createGitRepo('hyperlight-wasm');
-    // origin remote is the fork (jsturtevant), but project.repo is upstream (hyperlight-dev)
+    // git remote origin = testowner/hyperlight-wasm (set by createGitRepo),
+    // but project.repo is the upstream (hyperlight-dev) — resolveProjectRepo should prefer it
     writeProjects([{
       name: 'hyperlight-wasm',
       repo: 'hyperlight-dev/hyperlight-wasm',
@@ -377,5 +378,19 @@ describe('resolveRepo', () => {
     const result = resolveRepo();
     assert.strictEqual(result.owner, 'testowner');
     assert.strictEqual(result.repo, 'old-project');
+  });
+
+  test('malformed project.repo throws descriptive error', () => {
+    const repoPath = createGitRepo('bad-repo-format');
+    writeProjects([{
+      name: 'bad-repo-format',
+      repo: 'not-a-valid-repo-format',
+      path: repoPath,
+    }]);
+    process.chdir(repoPath);
+
+    assert.throws(() => resolveRepo(), {
+      message: /Invalid repo format.*not-a-valid-repo-format.*projects\.yaml/,
+    });
   });
 });


### PR DESCRIPTION
## Problem

When a project is a fork (e.g. `jsturtevant/hyperlight-wasm` forked from `hyperlight-dev/hyperlight-wasm`), dispatching an issue or PR fails because `resolveRepo()` reads the git remote `origin` URL — which points to the fork. Issues and PRs live in the upstream repo, not the fork.

```
rally dispatch pr 344
RallyError: PR #344 not found in jsturtevant/hyperlight-wasm
```

## Root Cause

`resolveRepo()` in `lib/dispatch.js` called `getRemoteRepo()` for cwd detection and single-project fallback. `getRemoteRepo()` reads `git remote get-url origin`, which after `rally onboard --fork` points to the user's fork (origin was renamed to upstream, fork set as origin).

## Fix

Added `resolveProjectRepo()` helper that prefers `project.repo` from `projects.yaml` (always the upstream) over git remote origin. Falls back to `getRemoteRepo()` for legacy entries without a `repo` field.

## Tests

5 new tests covering:
- cwd detection uses upstream repo for fork projects
- single-project fallback uses upstream repo for fork projects  
- git remote origin is NOT used when project.repo exists
- non-fork projects with repo field still work
- legacy projects without repo field fall back to git remote

All 86 dispatch tests pass. No regressions.

Closes #223