### PR TITLE
feat: add 'pushed' status and dashboard shortcut

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import yaml from 'js-yaml';
 import { getConfigDir, readActive, atomicWrite } from './config.js';
 
-const VALID_STATUSES = ['planning', 'implementing', 'reviewing', 'done', 'cleaned'];
+const VALID_STATUSES = ['planning', 'implementing', 'reviewing', 'pushed', 'done', 'cleaned'];
 
 const REQUIRED_FIELDS = ['id', 'repo', 'number', 'type', 'branch', 'worktreePath', 'status', 'session_id'];
 

--- a/lib/dispatch-clean.js
+++ b/lib/dispatch-clean.js
@@ -6,7 +6,7 @@ import { readProjects } from './config.js';
 import { findProjectPath } from './utils.js';
 
 /**
- * Clean dispatches with status "reviewing", "done", or "cleaned" by removing their worktrees,
+ * Clean dispatches with status "reviewing", "pushed", "done", or "cleaned" by removing their worktrees,
  * deleting local branches, and updating active.yaml.
  *
  * @param {object} [options]
@@ -55,7 +55,7 @@ export async function dispatchClean(options = {}) {
     }
     targets = dispatches;
   } else {
-    targets = dispatches.filter((d) => d.status === 'done' || d.status === 'cleaned' || d.status === 'reviewing');
+    targets = dispatches.filter((d) => d.status === 'done' || d.status === 'cleaned' || d.status === 'reviewing' || d.status === 'pushed');
   }
 
   if (targets.length === 0) {

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -7,6 +7,7 @@ import LogViewer from './components/LogViewer.jsx';
 import DetailView from './components/DetailView.jsx';
 import { computeSummary, getDashboardData, renderPlainDashboard } from './dashboard-data.js';
 import { dispatchRemove as defaultDispatchRemove } from '../dispatch-remove.js';
+import { updateDispatchStatus as defaultUpdateDispatchStatus } from '../active.js';
 import { parseSessionIdFromLog as defaultParseSessionId, UUID_RE } from '../copilot.js';
 
 export { computeSummary, getDashboardData, renderPlainDashboard };
@@ -33,7 +34,7 @@ function SummaryLine({ summary }) {
  * Supports keyboard navigation: ↑/↓ to select, Enter to open action menu, r to refresh, q to quit.
  * Auto-refreshes at the configured interval (default 5s).
  */
-export default function Dashboard({ project, onSelect, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchRemove = defaultDispatchRemove, _parseSessionIdFromLog = defaultParseSessionId }) {
+export default function Dashboard({ project, onSelect, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchRemove = defaultDispatchRemove, _parseSessionIdFromLog = defaultParseSessionId, _updateDispatchStatus = defaultUpdateDispatchStatus }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -149,6 +150,16 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       });
   }
 
+  function markAsPushed(dispatch) {
+    if (dispatch.status !== 'reviewing') return;
+    try {
+      _updateDispatchStatus(dispatch.id, 'pushed');
+      setRefreshKey(k => k + 1);
+    } catch (err) {
+      console.error(`Failed to mark dispatch as pushed: ${err.message}`);
+    }
+  }
+
   function handleActionSelect(direction) {
     if (direction === 'up') {
       setActionIndex(i => (i > 0 ? i - 1 : 0));
@@ -207,6 +218,8 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       setRefreshKey(k => k + 1);
     } else if (input === 'x' && count > 0) {
       removeSelectedDispatch(data.dispatches[selectedIndex]);
+    } else if (input === 'p' && count > 0) {
+      markAsPushed(data.dispatches[selectedIndex]);
     } else if (input === 'q') {
       exit();
     }
@@ -257,7 +270,7 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       <DispatchTable dispatches={data.dispatches} selectedIndex={selectedIndex} />
       <SummaryLine summary={data.summary} />
       <Box marginTop={1}>
-        <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · c connect IDE · l logs · x delete · r refresh · q quit</Text>
+        <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · c connect IDE · l logs · p pushed · x delete · r refresh · q quit</Text>
       </Box>
     </Box>
   );

--- a/lib/ui/components/DispatchTable.jsx
+++ b/lib/ui/components/DispatchTable.jsx
@@ -6,6 +6,7 @@ const STATUS_ICONS = {
   planning: '🔵',
   implementing: '⏳',
   reviewing: '🟡',
+  pushed: '🟣',
   done: '✅',
   cleaned: '⚪',
 };
@@ -18,6 +19,7 @@ function formatIssueRef(dispatch) {
 const STATUS_LABELS = {
   implementing: 'working',
   reviewing: 'ready for review',
+  pushed: 'pushed',
 };
 
 function formatStatus(status) {

--- a/lib/ui/dashboard-data.js
+++ b/lib/ui/dashboard-data.js
@@ -28,7 +28,7 @@ export function computeSummary(dispatches) {
   let orphaned = 0;
 
   for (const d of dispatches) {
-    if (d.status === 'done' || d.status === 'cleaned' || d.status === 'reviewing') {
+    if (d.status === 'done' || d.status === 'cleaned' || d.status === 'reviewing' || d.status === 'pushed') {
       done++;
     } else if (!d.healthy) {
       orphaned++;

--- a/test/active.test.js
+++ b/test/active.test.js
@@ -191,7 +191,7 @@ test('removeDispatch removes only the target record', () => {
 });
 
 test('VALID_STATUSES contains expected values', () => {
-  assert.deepEqual(VALID_STATUSES, ['planning', 'implementing', 'reviewing', 'done', 'cleaned']);
+  assert.deepEqual(VALID_STATUSES, ['planning', 'implementing', 'reviewing', 'pushed', 'done', 'cleaned']);
 });
 
 test('lock is released even when wrapped function throws', () => {

--- a/test/dispatch-clean.test.js
+++ b/test/dispatch-clean.test.js
@@ -324,3 +324,17 @@ test('dispatchClean continues when PID termination fails', async () => {
   // Should still clean despite termination error
   assert.strictEqual(result.cleaned.length, 1);
 });
+
+test('dispatchClean includes pushed status in default filter', async () => {
+  addDispatch(makeRecord({ id: 'd1', status: 'pushed' }));
+
+  const result = await dispatchClean({
+    _removeWorktree: () => {},
+    _readProjects: () => ({ projects: [{ name: 'rally', path: '/tmp/repo' }] }),
+    _exec: () => {},
+    _ora: silentOra,
+    _chalk: silentChalk,
+  });
+
+  assert.strictEqual(result.cleaned.length, 1, 'should clean dispatch with pushed status');
+});

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -103,6 +103,16 @@ describe('computeSummary', () => {
     assert.equal(summary.done, 0);
     assert.equal(summary.orphaned, 0);
   });
+
+  it('counts pushed dispatches in done bucket', () => {
+    const dispatches = [
+      { status: 'pushed', healthy: true },
+      { status: 'implementing', healthy: true },
+    ];
+    const summary = computeSummary(dispatches);
+    assert.equal(summary.done, 1, 'pushed should count as done');
+    assert.equal(summary.active, 1);
+  });
 });
 
 describe('getDashboardData', () => {
@@ -574,5 +584,53 @@ describe('Dashboard component', () => {
     await delay();
     const output = instance.lastFrame();
     assert.ok(!output.includes('Connect IDE session'), 'should not show Connect IDE for non-UUID session');
+  });
+
+  it('p shortcut marks reviewing dispatch as pushed', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].status = 'reviewing';
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    let updatedId;
+    let updatedStatus;
+    const mockUpdateStatus = (id, status) => {
+      updatedId = id;
+      updatedStatus = status;
+      return { id, status };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, {
+        refreshInterval: 0,
+        _updateDispatchStatus: mockUpdateStatus,
+      })
+    );
+    await delay();
+    instance.stdin.write('p');
+    await delay();
+    assert.equal(updatedId, 'd1', 'should update the selected dispatch');
+    assert.equal(updatedStatus, 'pushed', 'should set status to pushed');
+  });
+
+  it('p shortcut does nothing when dispatch is not reviewing', async () => {
+    let updateCalled = false;
+    const mockUpdateStatus = () => { updateCalled = true; return {}; };
+
+    instance = render(
+      React.createElement(Dashboard, {
+        refreshInterval: 0,
+        _updateDispatchStatus: mockUpdateStatus,
+      })
+    );
+    await delay();
+    instance.stdin.write('p');
+    await delay();
+    assert.ok(!updateCalled, 'p shortcut should not update non-reviewing dispatch');
+  });
+
+  it('help text includes p pushed shortcut', () => {
+    instance = render(React.createElement(Dashboard, { refreshInterval: 0 }));
+    const output = instance.lastFrame();
+    assert.ok(output.includes('p pushed'), 'should show p pushed shortcut hint');
   });
 });

--- a/test/ui/DispatchTable.test.js
+++ b/test/ui/DispatchTable.test.js
@@ -60,7 +60,7 @@ describe('DispatchTable', () => {
   });
 
   it('renders status icons for each status', () => {
-    const statuses = ['planning', 'implementing', 'reviewing', 'done', 'cleaned'];
+    const statuses = ['planning', 'implementing', 'reviewing', 'pushed', 'done', 'cleaned'];
     const dispatches = statuses.map((status, i) => ({
       repo: 'o/r',
       type: 'issue',


### PR DESCRIPTION
## Summary

Adds a new `pushed` status to the dispatch lifecycle and a `p` keyboard shortcut in the dashboard to transition dispatches from `reviewing` → `pushed`.

### What changed

- **`lib/active.js`**: Added `pushed` to `VALID_STATUSES`
- **`lib/ui/components/DispatchTable.jsx`**: Added 🟣 icon and label for `pushed` status
- **`lib/ui/Dashboard.jsx`**: Added `p` shortcut (only fires on `reviewing` dispatches), updated help text
- **`lib/dispatch-clean.js`**: Added `pushed` to default cleanup filter
- **`lib/ui/dashboard-data.js`**: `computeSummary` counts `pushed` in the `done` bucket

### Tests

- `test/active.test.js`: Updated `VALID_STATUSES` assertion
- `test/ui/DispatchTable.test.js`: Added `pushed` to status icon test
- `test/ui/Dashboard.test.js`: 3 new tests — `p` marks reviewing as pushed, `p` no-ops on non-reviewing, help text shows shortcut; 1 new computeSummary test for pushed
- `test/dispatch-clean.test.js`: New test verifying `pushed` dispatches get cleaned

Closes #222