### PR TITLE
feat: add 'Attach to session' action in dashboard

### DIFF
--- a/bin/rally.js
+++ b/bin/rally.js
@@ -99,7 +99,17 @@ const dashboard = program
         const React = await import('react');
         const { render } = await import('ink');
         const { default: Dashboard } = await import('../lib/ui/Dashboard.js');
-        render(React.createElement(Dashboard, { project: opts.project }), { fullScreen: true });
+        let attachDispatch = null;
+        const onAttachSession = (dispatch) => { attachDispatch = dispatch; };
+        const app = render(
+          React.createElement(Dashboard, { project: opts.project, onAttachSession }),
+          { fullScreen: true }
+        );
+        await app.waitUntilExit();
+        if (attachDispatch) {
+          const { dispatchContinue } = await import('../lib/dispatch-continue.js');
+          await dispatchContinue(attachDispatch.number, { repo: attachDispatch.repo });
+        }
       }
     } catch (err) {
       handleError(err);

--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -34,7 +34,7 @@ function SummaryLine({ summary }) {
  * Supports keyboard navigation: ↑/↓ to select, Enter to open action menu, r to refresh, q to quit.
  * Auto-refreshes at the configured interval (default 5s).
  */
-export default function Dashboard({ project, onSelect, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchRemove = defaultDispatchRemove, _parseSessionIdFromLog = defaultParseSessionId, _updateDispatchStatus = defaultUpdateDispatchStatus }) {
+export default function Dashboard({ project, onSelect, onAttachSession, refreshInterval = 5000, _spawn = defaultSpawn, _dispatchRemove = defaultDispatchRemove, _parseSessionIdFromLog = defaultParseSessionId, _updateDispatchStatus = defaultUpdateDispatchStatus }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -64,6 +64,7 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
     ? [
         ACTIONS.OPEN_VSCODE,
         ...(hasConnectableSession ? [ACTIONS.CONNECT_IDE] : []),
+        ...(actionDispatch.worktreePath ? [ACTIONS.ATTACH_SESSION] : []),
         ...(actionDispatch.logPath ? [ACTIONS.VIEW_LOGS] : []),
         ACTIONS.BACK,
       ]
@@ -160,6 +161,14 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
     }
   }
 
+  function attachToSession(dispatch) {
+    if (!dispatch.worktreePath) return;
+    if (onAttachSession) {
+      onAttachSession(dispatch);
+    }
+    exit();
+  }
+
   function handleActionSelect(direction) {
     if (direction === 'up') {
       setActionIndex(i => (i > 0 ? i - 1 : 0));
@@ -169,6 +178,8 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       openInVSCode(actionDispatch);
     } else if (direction === ACTIONS.CONNECT_IDE) {
       connectIDE(actionDispatch);
+    } else if (direction === ACTIONS.ATTACH_SESSION) {
+      attachToSession(actionDispatch);
     } else if (direction === ACTIONS.VIEW_LOGS) {
       viewLogs(actionDispatch);
     } else if (direction === 'confirm') {
@@ -177,6 +188,8 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
         openInVSCode(actionDispatch);
       } else if (selectedAction === ACTIONS.CONNECT_IDE) {
         connectIDE(actionDispatch);
+      } else if (selectedAction === ACTIONS.ATTACH_SESSION) {
+        attachToSession(actionDispatch);
       } else if (selectedAction === ACTIONS.VIEW_LOGS) {
         viewLogs(actionDispatch);
       } else {
@@ -211,6 +224,11 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       const selected = data.dispatches[selectedIndex];
       if (selected.session_id && UUID_RE.test(selected.session_id)) {
         connectIDE(selected);
+      }
+    } else if (input === 'a' && count > 0) {
+      const selected = data.dispatches[selectedIndex];
+      if (selected.worktreePath) {
+        attachToSession(selected);
       }
     } else if (input === 'l' && count > 0) {
       viewLogs(data.dispatches[selectedIndex]);
@@ -270,7 +288,7 @@ export default function Dashboard({ project, onSelect, refreshInterval = 5000, _
       <DispatchTable dispatches={data.dispatches} selectedIndex={selectedIndex} />
       <SummaryLine summary={data.summary} />
       <Box marginTop={1}>
-        <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · c connect IDE · l logs · p pushed · x delete · r refresh · q quit</Text>
+        <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · a attach · c connect IDE · l logs · p pushed · x delete · r refresh · q quit</Text>
       </Box>
     </Box>
   );

--- a/lib/ui/components/ActionMenu.jsx
+++ b/lib/ui/components/ActionMenu.jsx
@@ -5,6 +5,7 @@ import { UUID_RE } from '../../copilot.js';
 const ACTIONS = {
   OPEN_VSCODE: 'open-vscode',
   CONNECT_IDE: 'connect-ide',
+  ATTACH_SESSION: 'attach-session',
   VIEW_LOGS: 'view-logs',
   BACK: 'back',
 };
@@ -15,6 +16,7 @@ const ACTIONS = {
  */
 export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack }) {
   const hasLog = Boolean(dispatch.logPath);
+  const hasWorktree = Boolean(dispatch.worktreePath);
   const hasConnectableSession = dispatch.session_id &&
     UUID_RE.test(dispatch.session_id);
 
@@ -22,6 +24,9 @@ export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack 
     { id: ACTIONS.OPEN_VSCODE, label: '(v) Open in VS Code' },
     ...(hasConnectableSession
       ? [{ id: ACTIONS.CONNECT_IDE, label: '(c) Connect IDE session' }]
+      : []),
+    ...(hasWorktree
+      ? [{ id: ACTIONS.ATTACH_SESSION, label: '(a) Attach to session' }]
       : []),
     ...(hasLog ? [{ id: ACTIONS.VIEW_LOGS, label: '(l) View dispatch logs' }] : []),
     { id: ACTIONS.BACK, label: 'Back' },
@@ -32,6 +37,8 @@ export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack 
       onSelect(ACTIONS.OPEN_VSCODE);
     } else if (input === 'c' && hasConnectableSession) {
       onSelect(ACTIONS.CONNECT_IDE);
+    } else if (input === 'a' && hasWorktree) {
+      onSelect(ACTIONS.ATTACH_SESSION);
     } else if (input === 'l' && hasLog) {
       onSelect(ACTIONS.VIEW_LOGS);
     } else if (key.upArrow) {
@@ -61,7 +68,7 @@ export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack 
         </Box>
       ))}
       <Box marginTop={1}>
-        <Text dimColor>↑/↓ navigate · Enter confirm · v/l shortcut · Esc back</Text>
+        <Text dimColor>↑/↓ navigate · Enter confirm · v/a/l shortcut · Esc back</Text>
       </Box>
     </Box>
   );

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -435,6 +435,8 @@ describe('Dashboard component', () => {
     await delay();
     instance.stdin.write('\x1B[B');
     await delay();
+    instance.stdin.write('\x1B[B');
+    await delay();
     instance.stdin.write('\r');
     await delay();
     const output = instance.lastFrame();
@@ -632,5 +634,94 @@ describe('Dashboard component', () => {
     instance = render(React.createElement(Dashboard, { refreshInterval: 0 }));
     const output = instance.lastFrame();
     assert.ok(output.includes('p pushed'), 'should show p pushed shortcut hint');
+  });
+
+  it('help text includes a attach shortcut', () => {
+    instance = render(React.createElement(Dashboard, { refreshInterval: 0 }));
+    const output = instance.lastFrame();
+    assert.ok(output.includes('a attach'), 'should show a attach shortcut hint');
+  });
+
+  it('action menu shows Attach to session when dispatch has worktreePath', async () => {
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0 })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(output.includes('(a) Attach to session'), 'should show Attach option when worktreePath exists');
+  });
+
+  it('action menu hides Attach to session when no worktreePath', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].worktreePath = '';
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0 })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(!output.includes('(a) Attach to session'), 'should not show Attach when no worktreePath');
+  });
+
+  it('a shortcut calls onAttachSession with selected dispatch', async () => {
+    let attachedDispatch = null;
+    const onAttachSession = (dispatch) => { attachedDispatch = dispatch; };
+
+    instance = render(
+      React.createElement(Dashboard, {
+        refreshInterval: 0,
+        onAttachSession,
+      })
+    );
+    await delay();
+    instance.stdin.write('a');
+    await delay();
+    assert.ok(attachedDispatch, 'a shortcut should call onAttachSession');
+    assert.equal(attachedDispatch.number, 42, 'should pass the selected dispatch');
+    assert.equal(attachedDispatch.worktreePath, WORKTREE_DIR, 'should include worktreePath');
+  });
+
+  it('a shortcut does nothing when dispatch has no worktreePath', async () => {
+    const dispatches = makeSampleDispatches();
+    dispatches[0].worktreePath = '';
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    let attachCalled = false;
+    const onAttachSession = () => { attachCalled = true; };
+
+    instance = render(
+      React.createElement(Dashboard, {
+        refreshInterval: 0,
+        onAttachSession,
+      })
+    );
+    await delay();
+    instance.stdin.write('a');
+    await delay();
+    assert.ok(!attachCalled, 'a shortcut should not trigger when no worktreePath');
+  });
+
+  it('action menu Attach to session calls onAttachSession via shortcut', async () => {
+    let attachedDispatch = null;
+    const onAttachSession = (dispatch) => { attachedDispatch = dispatch; };
+
+    instance = render(
+      React.createElement(Dashboard, {
+        refreshInterval: 0,
+        onAttachSession,
+      })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    instance.stdin.write('a');
+    await delay();
+    assert.ok(attachedDispatch, 'action menu a shortcut should call onAttachSession');
+    assert.equal(attachedDispatch.number, 42, 'should pass dispatch number');
   });
 });


### PR DESCRIPTION
## Summary

Adds an **Attach to session** action to the Dashboard that works like `rally dispatch continue` — launches an interactive `gh copilot` session in the dispatch worktree.

### Changes

- **ActionMenu.jsx**: New `ATTACH_SESSION` action with `(a)` keyboard shortcut, only shown when dispatch has a worktree path
- **Dashboard.jsx**: `attachToSession` handler that calls `exit()` to cleanly leave the Ink fullscreen app, then fires `onAttachSession` callback; `a` shortcut from main dispatch list view
- **bin/rally.js**: Wires `onAttachSession` callback to `dispatchContinue()` after `waitUntilExit()`, so the interactive copilot session runs after Ink has released the terminal
- **Tests**: 6 new tests covering action visibility, shortcuts, and callback behavior; fixed 1 existing test for updated action menu order

### How it works

1. User presses `a` (or selects **Attach to session** from the action menu)
2. Dashboard exits Ink cleanly via `useApp().exit()`
3. After Ink unmounts, `dispatchContinue()` runs — resolves the session ID and spawns `gh copilot --resume` with `stdio: 'inherit'` so the user gets a fully interactive terminal session

Closes #220