### PR TITLE
chore: add CODEOWNERS for .squad/, CI, and package files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Squad configuration — require owner approval for changes to agent
+# charters, routing rules, team config, and governance files.
+/.squad/ @jsturtevant
+
+# CI workflows — require owner approval
+/.github/workflows/ @jsturtevant
+
+# Package manifests — require owner approval
+/package.json @jsturtevant
+/package-lock.json @jsturtevant


### PR DESCRIPTION
## Summary
Add CODEOWNERS file requiring @jsturtevant approval for changes to sensitive paths:

- `.squad/` — agent charters, routing rules, team config, governance
- `.github/workflows/` — CI pipelines  
- `package.json` / `package-lock.json` — dependencies

## Security
Prevents unauthorized modification of squad agent behavior via PR. Without CODEOWNERS, a malicious contributor could modify agent charters or routing rules in a PR, and a squad session running from that branch would read attacker-controlled config.

Closes #239