### PR TITLE
fix: validate API path segments in checkOrgMembership

### DIFF
--- a/lib/dispatch-trust.js
+++ b/lib/dispatch-trust.js
@@ -47,9 +47,12 @@ export function getItemAuthor(type, number, repo, _exec = execFileSync) {
  * @param {Function} [_exec] - Injectable execFileSync for testing
  * @returns {boolean|null} true if member, false if not, null if can't determine (e.g. user repo)
  */
+const SAFE_NAME_RE = /^[A-Za-z0-9_.-]+$/;
+
 export function checkOrgMembership(repo, username, _exec = execFileSync) {
   const owner = repo.split('/')[0];
   if (!owner || !username) return null;
+  if (!SAFE_NAME_RE.test(owner) || !SAFE_NAME_RE.test(username)) return null;
   try {
     // First check if the owner is an organization (not a user)
     const ownerType = _exec(

--- a/test/dispatch-trust.test.js
+++ b/test/dispatch-trust.test.js
@@ -99,6 +99,16 @@ describe('checkOrgMembership', () => {
     };
     assert.strictEqual(checkOrgMembership('someuser/repo', 'alice', exec), null);
   });
+
+  test('returns null when owner contains path traversal characters', () => {
+    const exec = () => { throw new Error('should not call API'); };
+    assert.strictEqual(checkOrgMembership('../etc/passwd/repo', 'alice', exec), null);
+  });
+
+  test('returns null when username contains unsafe characters', () => {
+    const exec = () => { throw new Error('should not call API'); };
+    assert.strictEqual(checkOrgMembership('myorg/repo', 'alice/../../admin', exec), null);
+  });
 });
 
 // =====================================================


### PR DESCRIPTION
## Summary
Add input validation to `checkOrgMembership()` — reject owner/username containing characters outside `[A-Za-z0-9_.-]` before interpolating into GitHub API paths (`users/{owner}`, `orgs/{owner}/members/{username}`).

## Changes
- `lib/dispatch-trust.js`: Added `SAFE_NAME_RE` validation before API calls
- `test/dispatch-trust.test.js`: 2 new tests — path traversal in owner and username

## Security
Prevents API path injection if this exported function is ever called with unvalidated input from a future code path.

Closes #240