### PR TITLE
fix: verify PID belongs to copilot before terminating

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -20,10 +20,13 @@ const LOCK_STALE_MS = 5 * 60 * 1000;
 export function terminatePid(pid, _kill = process.kill.bind(process), _readFileSync = readFileSync) {
   if (!pid || !Number.isFinite(pid)) return false;
   if (!Number.isInteger(pid) || pid <= 0) return false;
-  // Verify the PID belongs to a Copilot-related process before signaling
+  // Verify the PID belongs to a gh copilot process before signaling
   try {
     const cmdline = _readFileSync(`/proc/${pid}/cmdline`, 'utf8');
-    if (!cmdline.includes('copilot')) return false;
+    // cmdline uses NUL separators: "gh\0copilot\0..." — check for gh followed by copilot
+    const args = cmdline.split('\0');
+    const ghIdx = args.findIndex(a => a.endsWith('/gh') || a === 'gh');
+    if (ghIdx === -1 || args[ghIdx + 1] !== 'copilot') return false;
   } catch {
     // /proc not available (macOS/Windows) or process gone — proceed best-effort
   }

--- a/test/active.test.js
+++ b/test/active.test.js
@@ -334,13 +334,31 @@ test('terminatePid returns false when kill throws (best-effort)', () => {
   assert.strictEqual(result, false);
 });
 
-test('terminatePid returns false when PID is not a copilot process', () => {
+test('terminatePid returns false when PID is not a gh copilot process', () => {
   let killed = false;
   const mockKill = () => { killed = true; };
   const mockRead = () => '/usr/bin/node\0server.js';
   const result = terminatePid(12345, mockKill, mockRead);
   assert.strictEqual(result, false);
   assert.strictEqual(killed, false, 'should not kill non-copilot processes');
+});
+
+test('terminatePid rejects false positive with copilot in path', () => {
+  let killed = false;
+  const mockKill = () => { killed = true; };
+  const mockRead = () => '/home/user/copilot-backup/script.sh\0arg1';
+  const result = terminatePid(12345, mockKill, mockRead);
+  assert.strictEqual(result, false);
+  assert.strictEqual(killed, false, 'should not kill process with copilot only in path');
+});
+
+test('terminatePid accepts gh with full path', () => {
+  let captured;
+  const mockKill = (pid, signal) => { captured = { pid, signal }; };
+  const mockRead = () => '/usr/bin/gh\0copilot\0--resume\0abc';
+  const result = terminatePid(12345, mockKill, mockRead);
+  assert.strictEqual(result, true);
+  assert.deepStrictEqual(captured, { pid: 12345, signal: 'SIGTERM' });
 });
 
 test('terminatePid proceeds when /proc is unavailable', () => {


### PR DESCRIPTION
## Summary
Before sending SIGTERM to a stored PID, verify via `/proc/{pid}/cmdline` that the process is actually a Copilot process. Falls back to best-effort termination on platforms without /proc (macOS/Windows).

## Changes
- `lib/active.js`: Added /proc/cmdline check in `terminatePid()`, injectable `_readFileSync` for testing
- `test/active.test.js`: 2 new tests (non-copilot PID rejection, /proc unavailable fallback)

Closes #245