### PR TITLE
fix: validate RALLY_HOME and restrict config directory permissions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,8 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname, basename, isAbsolute } from 'node:path';
 import yaml from 'js-yaml';
+
 
 export function atomicWrite(filePath, content) {
   const dir = dirname(filePath);
@@ -12,7 +13,12 @@ export function atomicWrite(filePath, content) {
 }
 
 export function getConfigDir() {
-  if (process.env.RALLY_HOME) return process.env.RALLY_HOME;
+  if (process.env.RALLY_HOME) {
+    if (!isAbsolute(process.env.RALLY_HOME)) {
+      throw new Error(`RALLY_HOME must be an absolute path, got: "${process.env.RALLY_HOME}"`);
+    }
+    return process.env.RALLY_HOME;
+  }
   const newDefault = join(homedir(), 'rally');
   const legacyDefault = join(homedir(), '.rally');
   // Prefer new location; fall back to legacy ~/.rally if it exists and ~/rally does not
@@ -36,7 +42,7 @@ export function readConfig() {
 export function writeConfig(data) {
   const configDir = getConfigDir();
   if (!existsSync(configDir)) {
-    mkdirSync(configDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
   }
   const configPath = join(configDir, 'config.yaml');
   const content = yaml.dump(data);
@@ -59,7 +65,7 @@ export function readProjects() {
 export function writeProjects(data) {
   const configDir = getConfigDir();
   if (!existsSync(configDir)) {
-    mkdirSync(configDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
   }
   const projectsPath = join(configDir, 'projects.yaml');
   const content = yaml.dump(data);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -116,6 +116,20 @@ test('getConfigDir respects RALLY_HOME env var', () => {
   }
 });
 
+test('getConfigDir throws when RALLY_HOME is a relative path', () => {
+  const originalEnv = process.env.RALLY_HOME;
+  try {
+    process.env.RALLY_HOME = 'relative/path';
+    assert.throws(() => getConfigDir(), /RALLY_HOME must be an absolute path/);
+  } finally {
+    if (originalEnv) {
+      process.env.RALLY_HOME = originalEnv;
+    } else {
+      delete process.env.RALLY_HOME;
+    }
+  }
+});
+
 test('readConfig returns null when file missing', () => {
   const originalEnv = process.env.RALLY_HOME;
   const tempDir = mkdtempSync(join(tmpdir(), 'rally-test-'));


### PR DESCRIPTION
## Summary
Two low-severity security fixes:

1. **RALLY_HOME validation (#252):** Reject relative paths with a clear error. Prevents accidental use of attacker-controlled relative paths that could write config to unexpected locations.

2. **Config directory permissions (#251):** Create config directory with `mode: 0o700` (owner read/write/execute only). Prevents other users on shared systems from reading config files.

## Changes
- `lib/config.js`: `isAbsolute()` check for RALLY_HOME, `mode: 0o700` on mkdirSync
- `test/config.test.js`: Test for relative path rejection

Closes #251, closes #252