### PR TITLE
fix: handle ENOENT race in stale lock cleanup

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -139,8 +139,14 @@ function acquireLock() {
       if (staleCheck.stale) {
         try {
           rmSync(lockDir, { recursive: true, force: true });
+          // Immediately re-attempt mkdirSync so another process cannot
+          // slip in between removal and the next loop iteration.
           continue;
         } catch (cleanupErr) {
+          if (cleanupErr.code === 'ENOENT') {
+            // Another process already removed the stale lock — retry
+            continue;
+          }
           console.error(`Warning: failed to cleanup stale lock at ${lockDir}: ${cleanupErr.message}`);
           continue;
         }


### PR DESCRIPTION
Handle the race where two processes detect a stale lock simultaneously — the second `rmSync` finds it already removed.

## Changes
- Catch `ENOENT` from `rmSync` during stale lock cleanup and silently retry instead of logging a warning
- This closes the small race window documented in the issue

Closes #256