### PR TITLE
fix: add explicit permissions to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Adds an explicit `permissions:` block to `.github/workflows/ci.yml` with minimal required permissions (`contents: read`).

## Audit Results

Audited all 11 workflow files in `.github/workflows/`. Only `ci.yml` was missing a `permissions:` block — all other workflows already had appropriate minimal permissions configured:

| Workflow | Permissions | Status |
|----------|------------|--------|
| ci.yml | `contents: read` | **Added** ✅ |
| rally-docs.yml | `contents: read`, `pages: write`, `id-token: write` | Already present |
| rally-heartbeat.yml | `issues: write`, `contents: read`, `pull-requests: read` | Already present |
| rally-insider-release.yml | `contents: write` | Already present |
| rally-issue-assign.yml | `issues: write`, `contents: read` | Already present |
| rally-label-enforce.yml | `issues: write`, `contents: read` | Already present |
| rally-preview.yml | `contents: read` | Already present |
| rally-promote.yml | `contents: write` | Already present |
| rally-release.yml | `contents: write` | Already present |
| rally-triage.yml | `issues: write`, `contents: read` | Already present |
| sync-rally-labels.yml | `issues: write`, `contents: read` | Already present |

Follows the principle of least privilege for GitHub Actions security.

Closes #244