### PR TITLE
feat: make dashboard fill terminal width

### DIFF
--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -5,12 +5,12 @@ import DispatchTable from './components/DispatchTable.jsx';
 import ActionMenu, { ACTIONS } from './components/ActionMenu.jsx';
 import LogViewer from './components/LogViewer.jsx';
 import DetailView from './components/DetailView.jsx';
-import { computeSummary, getDashboardData, renderPlainDashboard } from './dashboard-data.js';
+import { computeSummary, getDashboardData, renderPlainDashboard, groupByProject } from './dashboard-data.js';
 import { dispatchRemove as defaultDispatchRemove } from '../dispatch-remove.js';
 import { updateDispatchStatus as defaultUpdateDispatchStatus } from '../active.js';
 import { parseSessionIdFromLog as defaultParseSessionId, UUID_RE } from '../copilot.js';
 
-export { computeSummary, getDashboardData, renderPlainDashboard };
+export { computeSummary, getDashboardData, renderPlainDashboard, groupByProject };
 
 /**
  * Summary line component.
@@ -285,7 +285,7 @@ export default function Dashboard({ project, onSelect, onAttachSession, refreshI
       <Box marginBottom={1}>
         <Text bold>Rally Dashboard</Text>
       </Box>
-      <DispatchTable dispatches={data.dispatches} selectedIndex={selectedIndex} />
+      <DispatchTable dispatches={data.dispatches} selectedIndex={selectedIndex} width={stdout.columns} />
       <SummaryLine summary={data.summary} />
       <Box marginTop={1}>
         <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · a attach · c connect IDE · l logs · p pushed · x delete · r refresh · q quit</Text>

--- a/lib/ui/components/DispatchTable.jsx
+++ b/lib/ui/components/DispatchTable.jsx
@@ -1,51 +1,64 @@
-import React from 'react';
-import { Box, Text } from 'ink';
-import { formatAge } from '../dashboard-data.js';
+import React from "react";
+import { Box, Text } from "ink";
+import { formatAge } from "../dashboard-data.js";
 
 const STATUS_ICONS = {
-  planning: '🔵',
-  implementing: '⏳',
-  reviewing: '🟡',
-  pushed: '🟣',
-  done: '✅',
-  cleaned: '⚪',
+  planning: "🔵",
+  implementing: "⏳",
+  reviewing: "🟡",
+  pushed: "🟣",
+  done: "✅",
+  cleaned: "⚪",
 };
 
 function formatIssueRef(dispatch) {
-  const prefix = dispatch.type === 'pr' ? 'PR' : 'Issue';
+  const prefix = dispatch.type === "pr" ? "PR" : "Issue";
   return `${prefix} #${dispatch.number}`;
 }
 
 const STATUS_LABELS = {
-  implementing: 'working',
-  reviewing: 'ready for review',
-  pushed: 'pushed',
+  implementing: "working",
+  reviewing: "review",
+  pushed: "pushed",
 };
 
 function formatStatus(status) {
-  const icon = STATUS_ICONS[status] ?? '?';
+  const icon = STATUS_ICONS[status] ?? "?";
   const label = STATUS_LABELS[status] ?? status;
   return `${icon} ${label}`;
 }
 
-const COLUMNS = [
-  { key: 'project', label: 'Project', width: 18 },
-  { key: 'issueRef', label: 'Issue/PR', width: 12 },
-  { key: 'status', label: 'Status', width: 20 },
-  { key: 'changes', label: 'Changes', width: 10 },
-  { key: 'age', label: 'Age', width: 6 },
+const SELECTOR_WIDTH = 2;
+
+const FIXED_COLUMNS = [
+  { key: "issueRef", label: "Issue/PR", minWidth: 12 },
+  { key: "status", label: "Status", minWidth: 16 },
+  { key: "changes", label: "Changes", minWidth: 10 },
+  { key: "age", label: "Age", minWidth: 6 },
 ];
 
-function TableRow({ cells, selected }) {
+const FIXED_TOTAL = SELECTOR_WIDTH + FIXED_COLUMNS.reduce((sum, c) => sum + c.minWidth, 0);
+const MIN_PROJECT_WIDTH = 18;
+
+function computeColumns(terminalWidth = 80) {
+  const available = Math.max(terminalWidth, FIXED_TOTAL + MIN_PROJECT_WIDTH);
+  const projectWidth = available - FIXED_TOTAL;
+  return [
+    { key: "project", label: "Project", width: projectWidth },
+    ...FIXED_COLUMNS.map(c => ({ ...c, width: c.minWidth })),
+  ];
+}
+
+function TableRow({ cells, columns, selected, width }) {
   return (
-    <Box>
-      <Box width={2}>
-        <Text color="cyan">{selected ? '❯' : ' '}</Text>
+    <Box width={width}>
+      <Box width={SELECTOR_WIDTH}>
+        <Text color="cyan">{selected ? "❯" : " "}</Text>
       </Box>
-      {COLUMNS.map((col) => (
+      {columns.map((col) => (
         <Box key={col.key} width={col.width} paddingRight={1}>
           <Text bold={selected}>
-            {cells[col.key] ?? ''}
+            {cells[col.key] ?? ""}
           </Text>
         </Box>
       ))}
@@ -53,41 +66,35 @@ function TableRow({ cells, selected }) {
   );
 }
 
-export default function DispatchTable({ dispatches = [], selectedIndex = -1 }) {
-  const rows = dispatches.map((d) => {
-    return {
-      project: d.repo ?? '',
-      issueRef: formatIssueRef(d),
-      status: formatStatus(d.status),
-      changes: d.changes ?? '',
-      age: formatAge(d.created ?? d.created_at),
-    };
-  });
+export default function DispatchTable({ dispatches = [], selectedIndex = -1, width }) {
+  const columns = computeColumns(width);
+  const rows = dispatches.map((d) => ({
+    project: d.repo ?? "",
+    issueRef: formatIssueRef(d),
+    status: formatStatus(d.status),
+    changes: d.changes ?? "",
+    age: formatAge(d.created ?? d.created_at),
+  }));
 
   return (
-    <Box flexDirection="column">
-      {/* Header */}
-      <Box>
-        <Box width={2}><Text> </Text></Box>
-        {COLUMNS.map((col) => (
+    <Box flexDirection="column" width={width}>
+      <Box width={width}>
+        <Box width={SELECTOR_WIDTH}><Text> </Text></Box>
+        {columns.map((col) => (
           <Box key={col.key} width={col.width} paddingRight={1}>
             <Text bold underline>{col.label}</Text>
           </Box>
         ))}
       </Box>
-
-      {/* Data rows */}
       {rows.length === 0 ? (
-        <Box>
-          <Text dimColor>No active dispatches</Text>
-        </Box>
+        <Box><Text dimColor>No active dispatches</Text></Box>
       ) : (
         rows.map((row, i) => (
-          <TableRow key={dispatches[i].id ?? i} cells={row} selected={i === selectedIndex} />
+          <TableRow key={dispatches[i].id ?? i} cells={row} columns={columns} selected={i === selectedIndex} width={width} />
         ))
       )}
     </Box>
   );
 }
 
-export { STATUS_ICONS };
+export { STATUS_ICONS, computeColumns };

--- a/test/ui/DispatchTable.test.js
+++ b/test/ui/DispatchTable.test.js
@@ -158,3 +158,56 @@ describe('formatAge', () => {
     assert.equal(formatAge(future), '0m');
   });
 });
+
+import { computeColumns } from "../../lib/ui/components/DispatchTable.js";
+
+describe("computeColumns", () => {
+  it("returns all five columns", () => {
+    const cols = computeColumns(120);
+    assert.deepEqual(cols.map(c => c.key), ["project", "issueRef", "status", "changes", "age"]);
+  });
+  it("gives Project more space on wider terminals", () => {
+    const n = computeColumns(80).find(c => c.key === "project").width;
+    const w = computeColumns(160).find(c => c.key === "project").width;
+    assert.ok(w > n);
+  });
+  it("enforces minimum Project width", () => {
+    assert.ok(computeColumns(20).find(c => c.key === "project").width >= 18);
+  });
+  it("defaults to 80 columns", () => {
+    assert.equal(computeColumns().find(c => c.key === "project").width, 34);
+  });
+  it("Project gets the most space", () => {
+    const cols = computeColumns(100);
+    const p = cols.find(c => c.key === "project").width;
+    cols.filter(c => c.key !== "project").forEach(c => assert.ok(p > c.width));
+  });
+});
+
+describe("DispatchTable width prop", () => {
+  it("accepts width prop", () => {
+    const { lastFrame, cleanup } = render(
+      React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES, width: 120 })
+    );
+    lastCleanup = cleanup;
+    assert.ok(lastFrame().includes("Project"));
+    assert.ok(lastFrame().includes("owner/repo-a"));
+  });
+  it("renders with defaults", () => {
+    const { lastFrame, cleanup } = render(
+      React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES })
+    );
+    lastCleanup = cleanup;
+    assert.ok(lastFrame().includes("Project"));
+  });
+});
+
+describe("Status label", () => {
+  it("uses review not ready for review", () => {
+    const d = [{ repo: "o/r", type: "issue", number: 1, status: "reviewing", created: new Date().toISOString() }];
+    const { lastFrame, cleanup } = render(React.createElement(DispatchTable, { dispatches: d }));
+    lastCleanup = cleanup;
+    assert.ok(lastFrame().includes("review"));
+    assert.ok(!lastFrame().includes("ready for review"));
+  });
+});


### PR DESCRIPTION
## Summary

The Rally Dashboard table was shorter than the navigation help text, leaving unused terminal space. This PR makes the dashboard fill the full terminal width.

### Changes

- **Dynamic column widths**: `DispatchTable` now accepts a `width` prop and uses `computeColumns()` to calculate column widths based on terminal size
- **Project column gets the most space**: All remaining width after fixed metadata columns goes to the Project column
- **Fixed metadata columns**: Issue/PR (12), Status (16), Changes (10), Age (6) stay at sensible fixed widths
- **Status label cleanup**: Shortened "ready for review" to "review" for a cleaner fit
- **Full-width rows**: Each row Box receives the terminal width for consistent alignment
- **Terminal width from Ink**: Dashboard passes `stdout.columns` (from `useStdout()`) to the table

### Tests

Added 8 new tests covering:
- `computeColumns` proportional width distribution
- Minimum project width enforcement on narrow terminals
- Width prop passthrough rendering
- Status label formatting

All 21 DispatchTable tests and 48 Dashboard tests pass.

Closes #232