### PR TITLE
refactor: consolidate GitHub URL parsers

### DIFF
--- a/lib/dispatch.js
+++ b/lib/dispatch.js
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { readProjects } from './config.js';
 import { RallyError, EXIT_GENERAL } from './errors.js';
+import { parseGitHubRemoteUrl } from './github-url.js';
 
 /**
  * Parse owner/repo from a --repo flag value.
@@ -39,16 +40,10 @@ export function getRemoteRepo(projectPath, opts = {}) {
     );
   }
 
-  // https://github.com/owner/repo.git or https://github.com/owner/repo
-  const httpsMatch = url.match(/github\.com\/([^/]+)\/([^/.]+)/);
-  if (httpsMatch) {
-    return { owner: httpsMatch[1], repo: httpsMatch[2] };
-  }
 
-  // git@github.com:owner/repo.git
-  const sshMatch = url.match(/github\.com:([^/]+)\/([^/.]+)/);
-  if (sshMatch) {
-    return { owner: sshMatch[1], repo: sshMatch[2] };
+  const parsed = parseGitHubRemoteUrl(url);
+  if (parsed) {
+    return parsed;
   }
 
   throw new Error(

--- a/lib/github-url.js
+++ b/lib/github-url.js
@@ -1,0 +1,54 @@
+/**
+ * Shared GitHub URL parser.
+ *
+ * Consolidates three independent parsers (onboard.js parseGithubUrl,
+ * onboard.js parseGitHubRemote, dispatch.js getRemoteRepo) into a
+ * single function that handles ALL GitHub URL formats.
+ */
+
+// Patterns ordered from most specific to least specific
+const PATTERNS = [
+  // HTTPS: https://github.com/owner/repo[.git]
+  /^https?:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+  // SCP-style: git@github.com:owner/repo[.git]
+  /^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+  // SSH or git:// protocols: ssh://git@github.com/owner/repo[.git] or git://github.com/owner/repo[.git]
+  /^(?:ssh|git):\/\/(?:git@)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+  // Shorthand: owner/repo (no protocol, no host)
+  /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/,
+];
+
+/**
+ * Parse any GitHub URL format into { owner, repo }.
+ *
+ * Supported formats:
+ *   - https://github.com/owner/repo[.git]
+ *   - git@github.com:owner/repo[.git]
+ *   - ssh://git@github.com/owner/repo[.git]
+ *   - git://github.com/owner/repo[.git]
+ *   - owner/repo (shorthand)
+ *
+ * @param {string} url - The URL or shorthand to parse
+ * @returns {{ owner: string, repo: string } | null} Parsed result or null
+ */
+export function parseGitHubRemoteUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+
+  const cleaned = url.trim().replace(/\/+$/, '');
+  if (!cleaned) return null;
+
+  for (const pattern of PATTERNS) {
+    const match = cleaned.match(pattern);
+    if (match) {
+      const owner = match[1];
+      const repo = match[2];
+      // Reject path-traversal attempts
+      if (owner.includes('..') || repo.includes('..') || owner === '.' || repo === '.') {
+        return null;
+      }
+      return { owner, repo };
+    }
+  }
+
+  return null;
+}

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -6,63 +6,30 @@ import { getConfigDir, readProjects, writeProjects } from './config.js';
 import { createSymlink } from './symlink.js';
 import { addExcludes, getExcludeEntries } from './exclude.js';
 import { selectTeam } from './team.js';
+import { parseGitHubRemoteUrl } from './github-url.js';
 
 /**
  * Parse a GitHub URL or owner/repo shorthand into clone metadata.
  * Returns { owner, repo, cloneUrl } or null if input looks like a local path.
+ *
+ * Higher-level wrapper around parseGitHubRemoteUrl that adds cloneUrl
+ * with protocol matching (SSH input → SSH clone URL, else HTTPS).
  */
 export function parseGithubUrl(input) {
-  if (!input) return null;
+  const parsed = parseGitHubRemoteUrl(input);
+  if (!parsed) return null;
 
-  // Strip trailing slashes so URLs like github.com/owner/repo/ still match
-  const cleaned = input.replace(/\/+$/, '');
+  const { owner, repo } = parsed;
 
-  // Full URL: https://github.com/owner/repo[.git]
-  const urlMatch = cleaned.match(
-    /^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/
-  );
-  if (urlMatch) {
-    const owner = urlMatch[1];
-    const repo = urlMatch[2];
-    if (repo.includes('..') || owner.includes('..')) return null;
-    return {
-      owner,
-      repo,
-      cloneUrl: `https://github.com/${owner}/${repo}.git`,
-    };
-  }
+  // Preserve the original protocol for the clone URL
+  const cleaned = (input || '').trim().replace(/\/+$/, '');
+  const isSsh = cleaned.startsWith('git@');
+  const cloneUrl = isSsh
+    ? `git@github.com:${owner}/${repo}.git`
+    : `https://github.com/${owner}/${repo}.git`;
 
-  // SSH URL: git@github.com:owner/repo[.git]
-  const sshMatch = cleaned.match(
-    /^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/
-  );
-  if (sshMatch) {
-    const owner = sshMatch[1];
-    const repo = sshMatch[2];
-    if (repo.includes('..') || owner.includes('..')) return null;
-    return {
-      owner,
-      repo,
-      cloneUrl: `git@github.com:${owner}/${repo}.git`,
-    };
-  }
-
-  // Shorthand: owner/repo (no slashes beyond the single separator, no path-like chars)
-  const shortMatch = cleaned.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
-  if (shortMatch) {
-    const owner = shortMatch[1];
-    const repo = shortMatch[2];
-    if (repo.includes('..') || owner.includes('..')) return null;
-    return {
-      owner,
-      repo,
-      cloneUrl: `https://github.com/${owner}/${repo}.git`,
-    };
-  }
-
-  return null;
+  return { owner, repo, cloneUrl };
 }
-
 /**
  * Validate fork format (must be owner/repo).
  */
@@ -197,32 +164,7 @@ export async function onboard(options = {}) {
         const isGitHubUrl = /github\.com/.test(remoteUrl);
 
         if (isGitHubUrl) {
-          const parseGitHubRemote = (url) => {
-            // Parse GitHub remote URL (supports https, ssh, git, SCP-style)
-            // Examples:
-            // - https://github.com/owner/repo
-            // - git@github.com:owner/repo
-            // - ssh://git@github.com/owner/repo
-            // - git://github.com/owner/repo
-            const patterns = [
-              // HTTPS: https://github.com/owner/repo.git
-              /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(\.git)?$/,
-              // SCP-style: git@github.com:owner/repo.git
-              /^git@github\.com:([^/]+)\/([^/]+?)(\.git)?$/,
-              // SSH/Git protocols: ssh://git@github.com/owner/repo.git or git://github.com/owner/repo.git
-              /^(?:ssh|git):\/\/(?:git@)?github\.com\/([^/]+)\/([^/]+?)(\.git)?$/,
-            ];
-
-            for (const pattern of patterns) {
-              const match = url.match(pattern);
-              if (match) {
-                return { host: 'github.com', owner: match[1], repo: match[2] };
-              }
-            }
-            return null;
-          };
-
-          const remoteInfo = parseGitHubRemote(remoteUrl);
+          const remoteInfo = parseGitHubRemoteUrl(remoteUrl);
           if (remoteInfo) {
             if (remoteInfo.owner !== parsed.owner || remoteInfo.repo !== parsed.repo) {
               throw new Error(

--- a/test/github-url.test.js
+++ b/test/github-url.test.js
@@ -1,0 +1,172 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseGitHubRemoteUrl } from '../lib/github-url.js';
+
+describe('parseGitHubRemoteUrl', () => {
+  describe('HTTPS URLs', () => {
+    it('parses https://github.com/owner/repo', () => {
+      const r = parseGitHubRemoteUrl('https://github.com/owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses https://github.com/owner/repo.git', () => {
+      const r = parseGitHubRemoteUrl('https://github.com/owner/repo.git');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses http:// variant', () => {
+      const r = parseGitHubRemoteUrl('http://github.com/owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('strips trailing slashes', () => {
+      const r = parseGitHubRemoteUrl('https://github.com/owner/repo/');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+  });
+
+  describe('SCP-style SSH URLs', () => {
+    it('parses git@github.com:owner/repo', () => {
+      const r = parseGitHubRemoteUrl('git@github.com:owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses git@github.com:owner/repo.git', () => {
+      const r = parseGitHubRemoteUrl('git@github.com:owner/repo.git');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+  });
+
+  describe('SSH protocol URLs', () => {
+    it('parses ssh://git@github.com/owner/repo', () => {
+      const r = parseGitHubRemoteUrl('ssh://git@github.com/owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses ssh://git@github.com/owner/repo.git', () => {
+      const r = parseGitHubRemoteUrl('ssh://git@github.com/owner/repo.git');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+  });
+
+  describe('git:// protocol URLs', () => {
+    it('parses git://github.com/owner/repo', () => {
+      const r = parseGitHubRemoteUrl('git://github.com/owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses git://github.com/owner/repo.git', () => {
+      const r = parseGitHubRemoteUrl('git://github.com/owner/repo.git');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('parses git://git@github.com/owner/repo', () => {
+      const r = parseGitHubRemoteUrl('git://git@github.com/owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+  });
+
+  describe('owner/repo shorthand', () => {
+    it('parses owner/repo', () => {
+      const r = parseGitHubRemoteUrl('owner/repo');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('handles dots and hyphens in names', () => {
+      const r = parseGitHubRemoteUrl('my-org/my.repo');
+      assert.deepStrictEqual(r, { owner: 'my-org', repo: 'my.repo' });
+    });
+
+    it('handles underscores', () => {
+      const r = parseGitHubRemoteUrl('my_org/my_repo');
+      assert.deepStrictEqual(r, { owner: 'my_org', repo: 'my_repo' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('trims whitespace', () => {
+      const r = parseGitHubRemoteUrl('  owner/repo  ');
+      assert.deepStrictEqual(r, { owner: 'owner', repo: 'repo' });
+    });
+
+    it('returns null for null input', () => {
+      assert.strictEqual(parseGitHubRemoteUrl(null), null);
+    });
+
+    it('returns null for undefined input', () => {
+      assert.strictEqual(parseGitHubRemoteUrl(undefined), null);
+    });
+
+    it('returns null for empty string', () => {
+      assert.strictEqual(parseGitHubRemoteUrl(''), null);
+    });
+
+    it('returns null for whitespace-only string', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('   '), null);
+    });
+
+    it('returns null for non-string input', () => {
+      assert.strictEqual(parseGitHubRemoteUrl(42), null);
+    });
+
+    it('returns null for non-GitHub host', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('https://gitlab.com/owner/repo'), null);
+    });
+
+    it('returns null for local paths', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('/home/user/repo'), null);
+    });
+
+    it('returns null for relative paths with multiple segments', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('a/b/c'), null);
+    });
+  });
+
+  describe('path traversal rejection', () => {
+    it('rejects .. in owner', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('../repo'), null);
+    });
+
+    it('rejects .. in repo', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('owner/..'), null);
+    });
+
+    it('rejects . as owner', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('./repo'), null);
+    });
+
+    it('rejects . as repo', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('owner/.'), null);
+    });
+
+    it('rejects .. in HTTPS URL owner', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('https://github.com/../repo'), null);
+    });
+
+    it('rejects .. in HTTPS URL repo', () => {
+      assert.strictEqual(parseGitHubRemoteUrl('https://github.com/owner/..'), null);
+    });
+  });
+
+  describe('real-world URLs', () => {
+    it('parses jsturtevant/rally HTTPS', () => {
+      const r = parseGitHubRemoteUrl('https://github.com/jsturtevant/rally.git');
+      assert.deepStrictEqual(r, { owner: 'jsturtevant', repo: 'rally' });
+    });
+
+    it('parses jsturtevant/rally SSH', () => {
+      const r = parseGitHubRemoteUrl('git@github.com:jsturtevant/rally.git');
+      assert.deepStrictEqual(r, { owner: 'jsturtevant', repo: 'rally' });
+    });
+
+    it('parses jsturtevant/rally shorthand', () => {
+      const r = parseGitHubRemoteUrl('jsturtevant/rally');
+      assert.deepStrictEqual(r, { owner: 'jsturtevant', repo: 'rally' });
+    });
+
+    it('parses hyperlight-dev/hyperlight-wasm', () => {
+      const r = parseGitHubRemoteUrl('https://github.com/hyperlight-dev/hyperlight-wasm');
+      assert.deepStrictEqual(r, { owner: 'hyperlight-dev', repo: 'hyperlight-wasm' });
+    });
+  });
+});


### PR DESCRIPTION
Unifies three separate GitHub URL parsing implementations into a single shared module (`lib/github-url.js`).

Closes #289

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>