### PR TITLE
fix: consolidate PID-alive checking into shared isPidAlive (#290)

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { slugify, findProjectPath } from '../lib/utils.js';
+import { slugify, findProjectPath, isPidAlive } from '../lib/utils.js';
 
 test('slugify creates URL-safe slugs', () => {
   assert.strictEqual(slugify('Hello World'), 'hello-world');
@@ -63,4 +63,32 @@ test('findProjectPath extracts repo name from owner/repo format', () => {
 
   const result = findProjectPath('github-org/my-project', mockReadProjects);
   assert.strictEqual(result, '/home/user/my-project');
+});
+
+// --- isPidAlive tests ---
+
+test('isPidAlive returns true for own process', () => {
+  assert.strictEqual(isPidAlive(process.pid), true);
+});
+
+test('isPidAlive returns false for invalid PID', () => {
+  assert.strictEqual(isPidAlive(-1), false);
+  assert.strictEqual(isPidAlive(0), false);
+  assert.strictEqual(isPidAlive(NaN), false);
+  assert.strictEqual(isPidAlive(Infinity), false);
+});
+
+test('isPidAlive returns false when kill throws ESRCH', () => {
+  const killEsrch = () => { const e = new Error('ESRCH'); e.code = 'ESRCH'; throw e; };
+  assert.strictEqual(isPidAlive(1234, killEsrch), false);
+});
+
+test('isPidAlive returns true when kill throws EPERM', () => {
+  const killEperm = () => { const e = new Error('EPERM'); e.code = 'EPERM'; throw e; };
+  assert.strictEqual(isPidAlive(1234, killEperm), true);
+});
+
+test('isPidAlive returns true when kill succeeds', () => {
+  const killOk = () => {};
+  assert.strictEqual(isPidAlive(1234, killOk), true);
 });


### PR DESCRIPTION
## Problem

`active.js` and `dispatch-refresh.js` had inconsistent PID-alive checking:
- `active.js` `isPidAlive()` correctly treated EPERM as "alive" (process exists but we lack permissions)
- `dispatch-refresh.js` `isProcessRunning()` caught all errors and returned `false`, incorrectly treating EPERM processes as dead

This could cause dispatch-refresh to prematurely transition dispatches to "reviewing" when the Copilot process is running under a different user/permission level.

## Solution

- Extract `isPidAlive(pid)` into `lib/utils.js` with consistent EPERM handling
- `active.js` imports and uses the shared function (removed local copy)
- `dispatch-refresh.js` `isProcessRunning()` delegates to the shared `isPidAlive()`
- Backward-compatible: `isProcessRunning` export name preserved for existing callers/tests

## Testing

All 67 tests in `active.test.js` and `dispatch-refresh.test.js` pass.

Closes #290