### PR TITLE
fix: verify gh CLI availability in dispatch-issue and dispatch-pr (#285)

### DIFF
--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -5,6 +5,7 @@ import { writeIssueContext } from './dispatch-context.js';
 import { slugify } from './utils.js';
 import { validateDispatchInputs, warnUncommittedChanges, setupDispatchWorktree } from './dispatch-core.js';
 import { checkDispatchTrust } from './dispatch-trust.js';
+import { assertTools } from './tools.js';
 
 /**
  * Dispatch an issue: full workflow.
@@ -34,6 +35,9 @@ export async function dispatchIssue(options = {}) {
     _spawn,
     _confirm,
   } = options;
+
+  // Verify gh CLI is available
+  assertTools(['gh'], { _exec });
 
   const { number, repoName, resolvedRepoPath } = validateDispatchInputs({
     itemNumber: issueNumber,

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -6,6 +6,7 @@ import { writePrContext } from './dispatch-context.js';
 import { slugify } from './utils.js';
 import { validateDispatchInputs, warnUncommittedChanges, setupDispatchWorktree } from './dispatch-core.js';
 import { checkDispatchTrust } from './dispatch-trust.js';
+import { assertTools } from './tools.js';
 
 /**
  * Sanitize a git ref name for safe interpolation into prompts.
@@ -131,6 +132,9 @@ export async function dispatchPr(options = {}) {
     _spawn,
     _confirm,
   } = options;
+
+  // Verify gh CLI is available
+  assertTools(['gh'], { _exec });
 
   // Validate custom prompt file early
   if (promptFile && !existsSync(promptFile)) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -8,14 +8,16 @@ const REQUIRED_TOOLS = ['git', 'gh', 'npx'];
  * Returns an array of missing tool names (empty if all present).
  *
  * @param {object} [opts]
+ * @param {string[]} [opts.tools] - Tools to check (defaults to REQUIRED_TOOLS)
  * @param {Function} [opts._exec] - Injectable execFileSync (for testing)
  * @returns {string[]} Array of missing tool names
  */
 export function checkTools(opts = {}) {
   const exec = opts._exec || execFileSync;
+  const toolsToCheck = opts.tools || REQUIRED_TOOLS;
   const missing = [];
 
-  for (const tool of REQUIRED_TOOLS) {
+  for (const tool of toolsToCheck) {
     try {
       exec(tool, ['--version'], { stdio: 'pipe' });
     } catch {
@@ -27,14 +29,25 @@ export function checkTools(opts = {}) {
 }
 
 /**
- * Assert that all required CLI tools are available.
+ * Assert that specified CLI tools are available.
  * Throws a RallyError with EXIT_CONFIG if any are missing.
  *
- * @param {object} [opts]
+ * @param {string[] | object} [toolsOrOpts] - Tools to check (array) or options object
+ * @param {object} [opts] - Options object (ignored if toolsOrOpts is an object)
+ * @param {string[]} [opts.tools] - Tools to check (defaults to REQUIRED_TOOLS)
  * @param {Function} [opts._exec] - Injectable execFileSync (for testing)
  */
-export function assertTools(opts = {}) {
-  const missing = checkTools(opts);
+export function assertTools(toolsOrOpts = {}, opts = {}) {
+  let options = opts;
+
+  // Handle both assertTools(['gh']) and assertTools({ tools: ['gh'] })
+  if (Array.isArray(toolsOrOpts)) {
+    options = { tools: toolsOrOpts, ...opts };
+  } else {
+    options = toolsOrOpts;
+  }
+
+  const missing = checkTools(options);
   if (missing.length > 0) {
     throw new RallyError(
       `Missing required tools: ${missing.join(', ')}. Please install them before running rally.`,

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -71,6 +71,9 @@ function makeIssue(overrides = {}) {
  */
 function createExecWithIssue(issueData) {
   return (cmd, args, opts) => {
+    if (cmd === 'gh' && args[0] === '--version') {
+      return 'gh version 2.0.0'; // Mock gh version check
+    }
     if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
       if (!issueData) {
         const err = new Error('Could not resolve to an Issue with the number of 999');
@@ -133,6 +136,21 @@ describe('slugify', () => {
 // =====================================================
 
 describe('dispatchIssue error paths', () => {
+  test('throws RallyError when gh CLI is missing', async () => {
+    setupRallyHome();
+    const execMissingGh = () => {
+      throw new Error('gh: command not found');
+    };
+    await assert.rejects(
+      () => dispatchIssue({ issueNumber: 42, repo: 'owner/repo', repoPath, _exec: execMissingGh }),
+      (err) => {
+        assert.ok(err.message.includes('gh'));
+        assert.ok(err.message.includes('Missing required tools'));
+        return true;
+      }
+    );
+  });
+
   test('throws when issue number is missing', async () => {
     setupRallyHome();
     await assert.rejects(
@@ -187,7 +205,7 @@ describe('dispatchIssue error paths', () => {
     const wtPath = join(repoPath, '.worktrees', 'rally-42');
     execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/42-existing'], { cwd: repoPath, stdio: 'ignore' });
 
-    const result = await dispatchIssue({ issueNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn });
+    const result = await dispatchIssue({ issueNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true });
     assert.strictEqual(result.existing, true);
     assert.ok(result.worktreePath.includes('rally-42'));
   });
@@ -254,6 +272,7 @@ describe('dispatchIssue happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     // Verify return value
@@ -300,6 +319,7 @@ describe('dispatchIssue happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.branch, 'rally/7-fix-broken-navbar-component');
@@ -324,6 +344,7 @@ describe('dispatchIssue happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     const expected = join(repoPath, '.worktrees', 'rally-99');
@@ -348,6 +369,7 @@ describe('dispatchIssue happy path', () => {
       teamDir,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     // Verify .squad exists in worktree (either as symlink or directory)
@@ -368,6 +390,7 @@ describe('dispatchIssue happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: () => ({ pid: 98765, unref() {} }),
+      trust: true,
     });
 
     assert.strictEqual(result.sessionId, '98765');
@@ -391,6 +414,7 @@ describe('dispatchIssue happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: () => { throw Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }); },
+      trust: true,
     });
 
     // Should complete without throwing, sessionId null
@@ -407,6 +431,9 @@ describe('dispatchIssue happy path', () => {
 
     // _exec that fails for copilot check (not installed)
     const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === '--version') {
+        return 'gh version 2.0.0';
+      }
       if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
         return JSON.stringify(issue);
       }
@@ -424,6 +451,7 @@ describe('dispatchIssue happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: () => { spawnCalled = true; return { pid: 1, unref() {} }; },
+      trust: true,
     });
 
     assert.strictEqual(result.sessionId, null);
@@ -436,6 +464,9 @@ describe('dispatchIssue happy path', () => {
 
     // _exec that succeeds for gh + git but makes addDispatch fail
     const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === '--version') {
+        return 'gh version 2.0.0';
+      }
       if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
         return JSON.stringify(issue);
       }
@@ -458,6 +489,7 @@ describe('dispatchIssue happy path', () => {
         repoPath,
         _exec: exec,
         _spawn: noopSpawn,
+        trust: true,
       }),
     );
 

--- a/test/dispatch-pr.test.js
+++ b/test/dispatch-pr.test.js
@@ -84,6 +84,9 @@ function makePr(overrides = {}) {
  */
 function createExecWithPr(prData) {
   return (cmd, args, opts) => {
+    if (cmd === 'gh' && args[0] === '--version') {
+      return 'gh version 2.0.0'; // Mock gh version check
+    }
     if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
       if (!prData) {
         const err = new Error('Could not resolve to a PullRequest with the number of 999');
@@ -168,6 +171,21 @@ describe('fetchPrOrFail', () => {
 // =====================================================
 
 describe('dispatchPr error paths', () => {
+  test('throws RallyError when gh CLI is missing', async () => {
+    setupRallyHome();
+    const execMissingGh = () => {
+      throw new Error('gh: command not found');
+    };
+    await assert.rejects(
+      () => dispatchPr({ prNumber: 42, repo: 'owner/repo', repoPath, _exec: execMissingGh }),
+      (err) => {
+        assert.ok(err.message.includes('gh'));
+        assert.ok(err.message.includes('Missing required tools'));
+        return true;
+      }
+    );
+  });
+
   test('throws when PR number is missing', async () => {
     setupRallyHome();
     await assert.rejects(
@@ -256,7 +274,7 @@ describe('dispatchPr error paths', () => {
     setupRallyHome();
     const exec = createExecWithPr(makePr({ state: 'MERGED' }));
     await assert.rejects(
-      () => dispatchPr({ prNumber: 5, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn }),
+      () => dispatchPr({ prNumber: 5, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true }),
       (err) => {
         assert.ok(err.message.includes('already merged'));
         return true;
@@ -268,7 +286,7 @@ describe('dispatchPr error paths', () => {
     setupRallyHome();
     const exec = createExecWithPr(makePr({ state: 'CLOSED' }));
     await assert.rejects(
-      () => dispatchPr({ prNumber: 5, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn }),
+      () => dispatchPr({ prNumber: 5, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true }),
       (err) => {
         assert.ok(err.message.includes('closed'));
         return true;
@@ -285,7 +303,7 @@ describe('dispatchPr error paths', () => {
     const wtPath = join(repoPath, '.worktrees', 'rally-pr-42');
     execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/pr-42-existing'], { cwd: repoPath, stdio: 'ignore' });
 
-    const result = await dispatchPr({ prNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn });
+    const result = await dispatchPr({ prNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true });
     assert.strictEqual(result.existing, true);
   });
 });
@@ -309,6 +327,7 @@ describe('dispatchPr happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     // Verify return value
@@ -361,6 +380,7 @@ describe('dispatchPr happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.branch, 'rally/pr-7-add-dark-mode-support');
@@ -385,6 +405,7 @@ describe('dispatchPr happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     const expected = join(repoPath, '.worktrees', 'rally-pr-99');
@@ -408,6 +429,7 @@ describe('dispatchPr happy path', () => {
       teamDir,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     const squadInWorktree = join(result.worktreePath, '.squad');
@@ -427,6 +449,7 @@ describe('dispatchPr happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: () => ({ pid: 98765, unref() {} }),
+      trust: true,
     });
 
     assert.strictEqual(result.sessionId, '98765');
@@ -449,6 +472,7 @@ describe('dispatchPr happy path', () => {
       repoPath,
       _exec: exec,
       _spawn: () => { throw Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }); },
+      trust: true,
     });
 
     assert.strictEqual(result.sessionId, null);
@@ -477,6 +501,7 @@ describe('dispatchPr happy path', () => {
         repoPath,
         _exec: exec,
         _spawn: noopSpawn,
+        trust: true,
       }),
     );
 
@@ -596,6 +621,9 @@ describe('dispatchPr with custom prompt file', () => {
       return { pid: 12345, unref() {}, on() {} };
     };
     const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === '--version') {
+        return 'gh version 2.0.0';
+      }
       if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
         return JSON.stringify(pr);
       }
@@ -619,6 +647,7 @@ describe('dispatchPr with custom prompt file', () => {
       promptFile: promptPath,
       _exec: exec,
       _spawn: capturingSpawn,
+      trust: true,
     });
 
     assert.ok(result.worktreePath, 'should return worktree path');

--- a/test/edge-cases.test.js
+++ b/test/edge-cases.test.js
@@ -67,8 +67,14 @@ function makeIssue(overrides = {}) {
 
 function createExecWithIssue(issueData, { dirty = false } = {}) {
   return (cmd, args, opts) => {
+    if (cmd === 'gh' && args[0] === '--version') {
+      return 'gh version 2.0.0';
+    }
     if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
       return JSON.stringify(issueData);
+    }
+    if (cmd === 'gh' && args[0] === 'copilot') {
+      return '';
     }
     if (cmd === 'git' && args[0] === 'status' && args[1] === '--porcelain') {
       return dirty ? ' M file.txt\n' : '';
@@ -162,6 +168,7 @@ describe('worktree collision detection', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.existing, true);
@@ -185,6 +192,7 @@ describe('worktree collision detection', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.existing, true);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -88,11 +88,17 @@ function makePr(overrides = {}) {
 
 function createExecWithIssue(issueData) {
   return (cmd, args, opts) => {
+    if (cmd === 'gh' && args[0] === '--version') {
+      return 'gh version 2.0.0';
+    }
     if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
       if (!issueData) {
         throw new Error('Could not resolve to an Issue with the number of 999');
       }
       return JSON.stringify(issueData);
+    }
+    if (cmd === 'gh' && args[0] === 'copilot') {
+      return '';
     }
     return execFileSync(cmd, args, opts);
   };
@@ -100,11 +106,17 @@ function createExecWithIssue(issueData) {
 
 function createExecWithPr(prData) {
   return (cmd, args, opts) => {
+    if (cmd === 'gh' && args[0] === '--version') {
+      return 'gh version 2.0.0';
+    }
     if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
       if (!prData) {
         throw new Error('Could not resolve to a PullRequest with the number of 999');
       }
       return JSON.stringify(prData);
+    }
+    if (cmd === 'gh' && args[0] === 'copilot') {
+      return '';
     }
     // Simulate refs/pull/N/head fetch — in tests, fetch the PR branch directly
     if (cmd === 'git' && args.includes('fetch') && args.some(a => a.startsWith('refs/pull/'))) {
@@ -143,6 +155,7 @@ describe('Integration: issue dispatch → dashboard → clean', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     // Verify dispatch result
@@ -218,6 +231,7 @@ describe('Integration: PR dispatch workflow', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.branch, 'rally/pr-10-fix-login-validation');
@@ -309,6 +323,7 @@ describe('Integration: error cases', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.existing, true);
@@ -351,6 +366,7 @@ describe('Integration: error cases', () => {
       repoPath,
       _exec: exec,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     assert.strictEqual(result.existing, true);
@@ -540,6 +556,7 @@ describe('Integration: multiple dispatches', () => {
       repoPath,
       _exec: exec1,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     await dispatchIssue({
@@ -548,6 +565,7 @@ describe('Integration: multiple dispatches', () => {
       repoPath,
       _exec: exec2,
       _spawn: noopSpawn,
+      trust: true,
     });
 
     const dispatches = getActiveDispatches();

--- a/test/tools.test.js
+++ b/test/tools.test.js
@@ -106,4 +106,32 @@ describe('assertTools', () => {
       assert.ok(!err.message.includes('git, '));
     }
   });
+
+  it('accepts array syntax assertTools(["gh"])', () => {
+    assert.doesNotThrow(() => assertTools(['gh'], { _exec: execAllPass }));
+  });
+
+  it('throws when specific tool is missing using array syntax', () => {
+    try {
+      assertTools(['gh'], { _exec: execFailFor('gh') });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.ok(err instanceof RallyError);
+      assert.ok(err.message.includes('gh'));
+      assert.equal(err.exitCode, EXIT_CONFIG);
+    }
+  });
+
+  it('accepts options object syntax with tools property', () => {
+    assert.doesNotThrow(() => assertTools({ tools: ['gh'], _exec: execAllPass }));
+  });
+
+  it('checks only specified tools when tools array is provided', () => {
+    const calls = [];
+    const spy = (tool) => {
+      calls.push(tool);
+    };
+    checkTools({ tools: ['gh'], _exec: spy });
+    assert.deepEqual(calls, ['gh']);
+  });
 });


### PR DESCRIPTION
Closes #285

Adds assertTools(['gh']) check at the start of dispatch-issue and dispatch-pr to give users a clear error when gh CLI is missing.