### PR TITLE
fix: handle TOCTOU race in worktree creation (#284)

### DIFF
--- a/lib/dispatch-core.js
+++ b/lib/dispatch-core.js
@@ -97,7 +97,14 @@ export function setupDispatchWorktree(opts) {
     _spawn,
   } = opts;
 
-  createWorktree(resolvedRepoPath, worktreePath, branch);
+  try {
+    createWorktree(resolvedRepoPath, worktreePath, branch);
+  } catch (err) {
+    if (err.code === 'WORKTREE_EXISTS') {
+      return { alreadyExists: true };
+    }
+    throw err;
+  }
 
   let copilotResult = { sessionId: null, pid: null, process: null, logPath: null };
   try {

--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -91,7 +91,7 @@ export async function dispatchIssue(options = {}) {
     };
   }
 
-  const { sessionId } = setupDispatchWorktree({
+  const setupResult = setupDispatchWorktree({
     resolvedRepoPath,
     worktreePath,
     branch,
@@ -110,10 +110,22 @@ export async function dispatchIssue(options = {}) {
     sandbox,
   });
 
+  if (setupResult.alreadyExists) {
+    console.error(`Warning: worktree already exists at ${worktreePath}, skipping creation`);
+    return {
+      branch,
+      worktreePath,
+      sessionId: null,
+      dispatchId,
+      issue: { number, title: issue.title },
+      existing: true,
+    };
+  }
+
   return {
     branch,
     worktreePath,
-    sessionId,
+    sessionId: setupResult.sessionId,
     dispatchId,
     issue: { number, title: issue.title },
   };

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -180,7 +180,7 @@ export async function dispatchPr(options = {}) {
     };
   }
 
-  const { sessionId } = setupDispatchWorktree({
+  const setupResult = setupDispatchWorktree({
     resolvedRepoPath,
     worktreePath,
     branch,
@@ -214,10 +214,22 @@ export async function dispatchPr(options = {}) {
     sandbox,
   });
 
+  if (setupResult.alreadyExists) {
+    console.error(`Warning: worktree already exists at ${worktreePath}, skipping creation`);
+    return {
+      branch,
+      worktreePath,
+      sessionId: null,
+      dispatchId,
+      pr: { number, title: pr.title },
+      existing: true,
+    };
+  }
+
   return {
     branch,
     worktreePath,
-    sessionId,
+    sessionId: setupResult.sessionId,
     dispatchId,
     pr: { number, title: pr.title },
   };

--- a/lib/worktree.js
+++ b/lib/worktree.js
@@ -44,6 +44,14 @@ export function createWorktree(repoPath, worktreePath, branchName) {
     );
     return absoluteWorktreePath;
   } catch (error) {
+    const errOutput = String(error.stderr || error.message || '');
+    if (errOutput.includes('already exists')) {
+      const raceErr = new Error(
+        `Worktree already exists at ${absoluteWorktreePath}`
+      );
+      raceErr.code = 'WORKTREE_EXISTS';
+      throw raceErr;
+    }
     throw new Error(
       `Failed to create worktree at ${absoluteWorktreePath}: ${error.message}`
     );

--- a/test/dispatch-issue.test.js
+++ b/test/dispatch-issue.test.js
@@ -210,6 +210,29 @@ describe('dispatchIssue error paths', () => {
     assert.ok(result.worktreePath.includes('rally-42'));
   });
 
+  test('handles TOCTOU race: worktree created between check and create', async () => {
+    setupRallyHome();
+    const issue = makeIssue();
+    const wtPath = join(repoPath, '.worktrees', 'rally-42');
+
+    // Mock _exec that creates the worktree during gh issue view (simulating concurrent dispatch)
+    const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === '--version') return 'gh version 2.0.0';
+      if (cmd === 'gh' && args[0] === 'issue' && args[1] === 'view') {
+        // Simulate race: another dispatch creates the worktree while we fetch the issue
+        execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/42-race-winner'], { cwd: repoPath, stdio: 'ignore' });
+        return JSON.stringify(issue);
+      }
+      if (cmd === 'gh' && args[0] === 'copilot') return '';
+      return execFileSync(cmd, args, opts);
+    };
+
+    const result = await dispatchIssue({ issueNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true });
+    assert.strictEqual(result.existing, true);
+    assert.ok(result.worktreePath.includes('rally-42'));
+    assert.strictEqual(result.sessionId, null);
+  });
+
   test('throws when repo is not onboarded', async () => {
     const rallyHome = process.env.RALLY_HOME;
     mkdirSync(rallyHome, { recursive: true });

--- a/test/dispatch-pr.test.js
+++ b/test/dispatch-pr.test.js
@@ -306,6 +306,29 @@ describe('dispatchPr error paths', () => {
     const result = await dispatchPr({ prNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true });
     assert.strictEqual(result.existing, true);
   });
+
+  test('handles TOCTOU race: worktree created between check and create', async () => {
+    setupRallyHome();
+    const pr = makePr();
+    const wtPath = join(repoPath, '.worktrees', 'rally-pr-42');
+
+    // Mock _exec that creates the worktree during gh pr view (simulating concurrent dispatch)
+    const exec = (cmd, args, opts) => {
+      if (cmd === 'gh' && args[0] === '--version') return 'gh version 2.0.0';
+      if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
+        // Simulate race: another dispatch creates the worktree while we fetch the PR
+        execFileSync('git', ['worktree', 'add', wtPath, '-b', 'rally/pr-42-race-winner'], { cwd: repoPath, stdio: 'ignore' });
+        return JSON.stringify(pr);
+      }
+      if (cmd === 'gh' && args[0] === 'copilot') return '';
+      return execFileSync(cmd, args, opts);
+    };
+
+    const result = await dispatchPr({ prNumber: 42, repo: 'owner/repo', repoPath, _exec: exec, _spawn: noopSpawn, trust: true });
+    assert.strictEqual(result.existing, true);
+    assert.ok(result.worktreePath.includes('rally-pr-42'));
+    assert.strictEqual(result.sessionId, null);
+  });
 });
 
 // =====================================================

--- a/test/worktree.test.js
+++ b/test/worktree.test.js
@@ -100,7 +100,21 @@ describe('worktree', () => {
     assert.equal(worktreeExists(repoPath, worktreePath), false);
   });
 
-  it('should throw when creating worktree with existing branch', () => {
+  it('should throw with WORKTREE_EXISTS code when path already exists', () => {
+    const worktreePath = join(testDir, 'worktree-dup');
+    createWorktree(repoPath, worktreePath, 'branch-first');
+
+    assert.throws(
+      () => createWorktree(repoPath, worktreePath, 'branch-second'),
+      (error) => {
+        assert.ok(error.message.includes('already exists'));
+        assert.strictEqual(error.code, 'WORKTREE_EXISTS');
+        return true;
+      }
+    );
+  });
+
+  it('should throw with WORKTREE_EXISTS code when branch already exists', () => {
     const worktreePath1 = join(testDir, 'worktree-6');
     const worktreePath2 = join(testDir, 'worktree-7');
     const branchName = 'duplicate-branch';
@@ -110,7 +124,8 @@ describe('worktree', () => {
     assert.throws(
       () => createWorktree(repoPath, worktreePath2, branchName),
       (error) => {
-        assert.ok(error.message.includes('Failed to create worktree'));
+        assert.ok(error.message.includes('already exists'));
+        assert.strictEqual(error.code, 'WORKTREE_EXISTS');
         return true;
       }
     );


### PR DESCRIPTION
Closes #284

Eliminates TOCTOU race by catching git's 'already exists' error during worktree creation and converting it to the friendly early-return path.

## What changed

- **lib/worktree.js**: `createWorktree()` now detects git "already exists" errors (both path and branch collisions) and throws with `code: 'WORKTREE_EXISTS'` instead of a generic error.
- **lib/dispatch-core.js**: `setupDispatchWorktree()` catches `WORKTREE_EXISTS` and returns `{ alreadyExists: true }` — skipping rollback (which would destroy the other dispatch's worktree).
- **lib/dispatch-issue.js** / **lib/dispatch-pr.js**: Callers check `setupResult.alreadyExists` and return the same friendly early-exit as the `worktreeExists()` check.
- **Tests**: 3 new tests covering the WORKTREE_EXISTS error code and TOCTOU race simulation in both dispatch flows.