### PR TITLE
refactor: replace console.log monkey-patching with mock.method (#295)

### DIFF
--- a/test/dispatch-continue.test.js
+++ b/test/dispatch-continue.test.js
@@ -22,12 +22,7 @@ const silentChalk = {
   dim: (s) => s,
 };
 
-// Suppress console.log during tests
-const hushLog = () => {
-  const orig = console.log;
-  console.log = () => {};
-  return () => { console.log = orig; };
-};
+// Suppress console.log during tests via t.mock.method — see individual tests
 
 test('throws when no dispatch found for the given number', async () => {
   await assert.rejects(
@@ -75,8 +70,8 @@ test('throws when no session ID available (pending, no log parse)', async () => 
   );
 });
 
-test('resolves session ID from log when stored value is a PID', async () => {
-  const restore = hushLog();
+test('resolves session ID from log when stored value is a PID', async (t) => {
+  t.mock.method(console, 'log', () => {});
   let resumedSessionId = null;
 
   await dispatchContinue(42, {
@@ -89,12 +84,11 @@ test('resolves session ID from log when stored value is a PID', async () => {
     _chalk: silentChalk,
   });
 
-  restore();
   assert.strictEqual(resumedSessionId, 'ses_resolved-from-log');
 });
 
-test('persists resolved session ID back via updateDispatchField', async () => {
-  const restore = hushLog();
+test('persists resolved session ID back via updateDispatchField', async (t) => {
+  t.mock.method(console, 'log', () => {});
   let fieldUpdates = [];
 
   await dispatchContinue(42, {
@@ -107,7 +101,6 @@ test('persists resolved session ID back via updateDispatchField', async () => {
     _chalk: silentChalk,
   });
 
-  restore();
   assert.strictEqual(fieldUpdates.length, 1);
   assert.deepEqual(fieldUpdates[0], {
     id: 'rally-issue-42',
@@ -116,8 +109,8 @@ test('persists resolved session ID back via updateDispatchField', async () => {
   });
 });
 
-test('sets status to implementing before resume, restores to reviewing after', async () => {
-  const restore = hushLog();
+test('sets status to implementing before resume, restores to reviewing after', async (t) => {
+  t.mock.method(console, 'log', () => {});
   let statusUpdates = [];
 
   await dispatchContinue(42, {
@@ -130,12 +123,11 @@ test('sets status to implementing before resume, restores to reviewing after', a
     _chalk: silentChalk,
   });
 
-  restore();
   assert.deepEqual(statusUpdates, ['implementing', 'reviewing']);
 });
 
-test('passes message option through to resumeCopilot', async () => {
-  const restore = hushLog();
+test('passes message option through to resumeCopilot', async (t) => {
+  t.mock.method(console, 'log', () => {});
   let capturedOpts = null;
 
   await dispatchContinue(42, {
@@ -149,14 +141,11 @@ test('passes message option through to resumeCopilot', async () => {
     _chalk: silentChalk,
   });
 
-  restore();
   assert.strictEqual(capturedOpts.message, 'focus on tests');
 });
 
-test('resume message includes dispatch id context', async () => {
-  const logs = [];
-  const origLog = console.log;
-  console.log = (...args) => { logs.push(args.join(' ')); };
+test('resume message includes dispatch id context', async (t) => {
+  const mockLog = t.mock.method(console, 'log', () => {});
 
   await dispatchContinue(42, {
     _getActiveDispatches: () => [makeRecord({ id: 'rally-42' })],
@@ -168,13 +157,12 @@ test('resume message includes dispatch id context', async () => {
     _chalk: silentChalk,
   });
 
-  console.log = origLog;
-  const msg = logs.join('\n');
+  const msg = mockLog.mock.calls.map((call) => call.arguments.join(' ')).join('\n');
   assert.ok(msg.includes('rally-42'), `Expected dispatch id in message, got: ${msg}`);
 });
 
-test('works with --repo filter for disambiguation', async () => {
-  const restore = hushLog();
+test('works with --repo filter for disambiguation', async (t) => {
+  t.mock.method(console, 'log', () => {});
   let resumedId = null;
 
   await dispatchContinue(42, {
@@ -191,12 +179,11 @@ test('works with --repo filter for disambiguation', async () => {
     _chalk: silentChalk,
   });
 
-  restore();
   assert.strictEqual(resumedId, 'sess-abc');
 });
 
-test('handles resume failure gracefully (status still restored)', async () => {
-  const restore = hushLog();
+test('handles resume failure gracefully (status still restored)', async (t) => {
+  t.mock.method(console, 'log', () => {});
   let statusUpdates = [];
 
   await assert.rejects(
@@ -212,7 +199,6 @@ test('handles resume failure gracefully (status still restored)', async () => {
     { message: 'resume failed' }
   );
 
-  restore();
   // Status should still be restored to 'reviewing' via finally block
   assert.deepEqual(statusUpdates, ['implementing', 'reviewing']);
 });

--- a/test/dispatch-log.test.js
+++ b/test/dispatch-log.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { dispatchLog } from '../lib/dispatch-log.js';
 
 describe('dispatchLog', () => {
-  test('displays log file content when dispatch is found', async () => {
+  test('displays log file content when dispatch is found', async (t) => {
     const mockGetActive = () => [
       {
         id: 'issue-42',
@@ -25,29 +25,23 @@ describe('dispatchLog', () => {
       return true;
     };
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        _getActiveDispatches: mockGetActive,
-        _readFile: mockReadFile,
-        _existsSync: mockExists,
-        _chalk: {
-          yellow: (s) => s,
-          dim: (s) => s,
-        },
-      });
+    await dispatchLog(42, {
+      _getActiveDispatches: mockGetActive,
+      _readFile: mockReadFile,
+      _existsSync: mockExists,
+      _chalk: {
+        yellow: (s) => s,
+        dim: (s) => s,
+      },
+    });
 
-      assert.strictEqual(output.length, 1);
-      assert.strictEqual(output[0], 'Copilot output here\nMore output\n');
-    } finally {
-      console.log = originalLog;
-    }
+    assert.strictEqual(mockLog.mock.calls.length, 1);
+    assert.strictEqual(mockLog.mock.calls[0].arguments[0], 'Copilot output here\nMore output\n');
   });
 
-  test('shows warning when logPath is missing', async () => {
+  test('shows warning when logPath is missing', async (t) => {
     const mockGetActive = () => [
       {
         id: 'issue-42',
@@ -58,26 +52,20 @@ describe('dispatchLog', () => {
       },
     ];
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        _getActiveDispatches: mockGetActive,
-        _chalk: {
-          yellow: (s) => `[yellow]${s}`,
-          dim: (s) => `[dim]${s}`,
-        },
-      });
+    await dispatchLog(42, {
+      _getActiveDispatches: mockGetActive,
+      _chalk: {
+        yellow: (s) => `[yellow]${s}`,
+        dim: (s) => `[dim]${s}`,
+      },
+    });
 
-      assert.ok(output.some((line) => line.includes('No log file available')));
-    } finally {
-      console.log = originalLog;
-    }
+    assert.ok(mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('No log file available')));
   });
 
-  test('shows warning when log file does not exist', async () => {
+  test('shows warning when log file does not exist', async (t) => {
     const mockGetActive = () => [
       {
         id: 'issue-42',
@@ -90,24 +78,18 @@ describe('dispatchLog', () => {
 
     const mockExists = () => false;
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        _getActiveDispatches: mockGetActive,
-        _existsSync: mockExists,
-        _chalk: {
-          yellow: (s) => `[yellow]${s}`,
-          dim: (s) => `[dim]${s}`,
-        },
-      });
+    await dispatchLog(42, {
+      _getActiveDispatches: mockGetActive,
+      _existsSync: mockExists,
+      _chalk: {
+        yellow: (s) => `[yellow]${s}`,
+        dim: (s) => `[dim]${s}`,
+      },
+    });
 
-      assert.ok(output.some((line) => line.includes('Log file not found')));
-    } finally {
-      console.log = originalLog;
-    }
+    assert.ok(mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('Log file not found')));
   });
 
   test('throws when no dispatch is found for number', async () => {
@@ -133,7 +115,7 @@ describe('dispatchLog', () => {
     );
   });
 
-  test('disambiguates with --repo flag', async () => {
+  test('disambiguates with --repo flag', async (t) => {
     const mockGetActive = () => [
       {
         id: 'issue-42-a',
@@ -158,26 +140,20 @@ describe('dispatchLog', () => {
 
     const mockExists = () => true;
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        repo: 'owner/repo2',
-        _getActiveDispatches: mockGetActive,
-        _readFile: mockReadFile,
-        _existsSync: mockExists,
-        _chalk: { yellow: (s) => s, dim: (s) => s },
-      });
+    await dispatchLog(42, {
+      repo: 'owner/repo2',
+      _getActiveDispatches: mockGetActive,
+      _readFile: mockReadFile,
+      _existsSync: mockExists,
+      _chalk: { yellow: (s) => s, dim: (s) => s },
+    });
 
-      assert.strictEqual(output[0], 'repo2 output\n');
-    } finally {
-      console.log = originalLog;
-    }
+    assert.strictEqual(mockLog.mock.calls[0].arguments[0], 'repo2 output\n');
   });
 
-  test('warns that --follow is not yet implemented', async () => {
+  test('warns that --follow is not yet implemented', async (t) => {
     const mockGetActive = () => [
       {
         id: 'issue-42',
@@ -191,26 +167,20 @@ describe('dispatchLog', () => {
     const mockReadFile = () => 'output\n';
     const mockExists = () => true;
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        follow: true,
-        _getActiveDispatches: mockGetActive,
-        _readFile: mockReadFile,
-        _existsSync: mockExists,
-        _chalk: { yellow: (s) => `[yellow]${s}`, dim: (s) => s },
-      });
+    await dispatchLog(42, {
+      follow: true,
+      _getActiveDispatches: mockGetActive,
+      _readFile: mockReadFile,
+      _existsSync: mockExists,
+      _chalk: { yellow: (s) => `[yellow]${s}`, dim: (s) => s },
+    });
 
-      assert.ok(output.some((line) => line.includes('--follow flag is not yet implemented')));
-    } finally {
-      console.log = originalLog;
-    }
+    assert.ok(mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('--follow flag is not yet implemented')));
   });
 
-  test('shows stats summary when log contains copilot stats', async () => {
+  test('shows stats summary when log contains copilot stats', async (t) => {
     const logContent = [
       'Some copilot output...',
       'Total code changes:     +164 -1',
@@ -229,31 +199,25 @@ describe('dispatchLog', () => {
       },
     ];
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        _getActiveDispatches: mockGetActive,
-        _readFile: () => logContent,
-        _existsSync: () => true,
-        _chalk: {
-          yellow: (s) => s,
-          dim: (s) => s,
-          bold: (s) => `[bold]${s}`,
-        },
-      });
+    await dispatchLog(42, {
+      _getActiveDispatches: mockGetActive,
+      _readFile: () => logContent,
+      _existsSync: () => true,
+      _chalk: {
+        yellow: (s) => s,
+        dim: (s) => s,
+        bold: (s) => `[bold]${s}`,
+      },
+    });
 
-      assert.ok(output.some((line) => line.includes('[bold]Stats:')));
-      assert.ok(output.some((line) => line.includes('+164 -1')));
-      assert.ok(output.some((line) => line.includes('Premium requests: 3')));
-    } finally {
-      console.log = originalLog;
-    }
+    assert.ok(mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('[bold]Stats:')));
+    assert.ok(mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('+164 -1')));
+    assert.ok(mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('Premium requests: 3')));
   });
 
-  test('shows log normally when no stats present', async () => {
+  test('shows log normally when no stats present', async (t) => {
     const logContent = 'Just regular output\nNo stats here\n';
 
     const mockGetActive = () => [
@@ -266,27 +230,21 @@ describe('dispatchLog', () => {
       },
     ];
 
-    let output = [];
-    const originalLog = console.log;
-    console.log = (...args) => output.push(args.join(' '));
+    const mockLog = t.mock.method(console, 'log', () => {});
 
-    try {
-      await dispatchLog(42, {
-        _getActiveDispatches: mockGetActive,
-        _readFile: () => logContent,
-        _existsSync: () => true,
-        _chalk: {
-          yellow: (s) => s,
-          dim: (s) => s,
-          bold: (s) => `[bold]${s}`,
-        },
-      });
+    await dispatchLog(42, {
+      _getActiveDispatches: mockGetActive,
+      _readFile: () => logContent,
+      _existsSync: () => true,
+      _chalk: {
+        yellow: (s) => s,
+        dim: (s) => s,
+        bold: (s) => `[bold]${s}`,
+      },
+    });
 
-      assert.ok(!output.some((line) => line.includes('[bold]Stats:')));
-      assert.strictEqual(output.length, 1);
-      assert.strictEqual(output[0], logContent);
-    } finally {
-      console.log = originalLog;
-    }
+    assert.ok(!mockLog.mock.calls.some((call) => call.arguments.join(' ').includes('[bold]Stats:')));
+    assert.strictEqual(mockLog.mock.calls.length, 1);
+    assert.strictEqual(mockLog.mock.calls[0].arguments[0], logContent);
   });
 });


### PR DESCRIPTION
Closes #295

Replaces manual console.log monkey-patching with node:test's built-in `t.mock.method()`. Auto-restores after each test, preventing cross-test contamination.

### Changes
- **test/dispatch-log.test.js** — Replaced 7 instances of `console.log = ...` / `try/finally` with `t.mock.method(console, 'log', () => {})`
- **test/dispatch-continue.test.js** — Removed `hushLog()` helper and 8 manual save/restore patterns, replaced with `t.mock.method()`

### Why
- Monkey-patching `console.log` is shared-state-unsafe — if a test throws before restore, all subsequent tests see the patched version
- `t.mock.method()` auto-restores when the test ends (pass or fail), eliminating cross-test contamination
- Net reduction: 56 fewer lines of boilerplate