### PR TITLE
refactor: standardize dependency injection pattern across dispatch modules (#293)

### DIFF
--- a/lib/dispatch-clean.js
+++ b/lib/dispatch-clean.js
@@ -1,4 +1,6 @@
 import chalk from 'chalk';
+import ora from 'ora';
+import { confirm } from '@inquirer/prompts';
 import { getActiveDispatches, removeDispatch } from './active.js';
 import { readProjects } from './config.js';
 import { findProjectPath } from './utils.js';
@@ -26,8 +28,8 @@ export async function dispatchClean(options = {}) {
   const _getActive = options._getActiveDispatches || getActiveDispatches;
   const _remove = options._removeDispatch || removeDispatch;
   const _readProj = options._readProjects || readProjects;
-  const _confirmFn = options._confirm || (await import('@inquirer/prompts')).confirm;
-  const _ora = options._ora || (await import('ora')).default;
+  const _confirmFn = options._confirm || confirm;
+  const _ora = options._ora || ora;
   const _chalk = options._chalk || chalk;
 
   const dispatches = _getActive();


### PR DESCRIPTION
Closes #293

Standardizes DI pattern across all dispatch modules to use static imports with options-based override for testability.

**What changed:** `dispatch-clean.js` was the only module using dynamic `await import()` for `ora` and `@inquirer/prompts`. This replaces those with static imports and the standard `options._dep || realDep` override pattern already used by every other dispatch module.

**Why:** Consistent DI patterns make the codebase easier for contributors to navigate. Static imports avoid unnecessary async overhead for deps that are always available.

All 232 tests pass.