### PR TITLE
fix: ensure proper Ink render cleanup in UI tests (#299)

### DIFF
--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -153,7 +153,10 @@ describe('Dashboard component', () => {
   });
 
   afterEach(() => {
-    if (instance) instance.unmount();
+    if (instance) {
+      instance.unmount();
+      instance.cleanup();
+    }
   });
 
   it('renders the dashboard title', () => {

--- a/test/ui/DetailView.test.js
+++ b/test/ui/DetailView.test.js
@@ -4,8 +4,13 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import DetailView from '../../lib/ui/components/DetailView.js';
 
-let lastCleanup;
-afterEach(() => { if (lastCleanup) lastCleanup(); });
+let lastInstance;
+afterEach(() => {
+  if (lastInstance) {
+    lastInstance.unmount();
+    lastInstance.cleanup();
+  }
+});
 
 const SAMPLE_DISPATCH = {
   repo: 'owner/repo-a',
@@ -24,11 +29,10 @@ const delay = () => new Promise(r => setImmediate(r));
 
 describe('DetailView', () => {
   it('renders detail header with issue ref', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: SAMPLE_DISPATCH, onBack: () => {} })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('Details for'), 'should show detail title');
     assert.ok(output.includes('Issue #42'), 'should show issue ref');
     assert.ok(output.includes('owner/repo-a'), 'should show repo name');
@@ -36,50 +40,45 @@ describe('DetailView', () => {
 
   it('renders PR ref for PR type', () => {
     const prDispatch = { ...SAMPLE_DISPATCH, type: 'pr', number: 7 };
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: prDispatch, onBack: () => {} })
     );
-    lastCleanup = cleanup;
-    assert.ok(lastFrame().includes('PR #7'), 'should show PR ref');
+    assert.ok(lastInstance.lastFrame().includes('PR #7'), 'should show PR ref');
   });
 
   it('displays branch, worktree, and session_id fields', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: SAMPLE_DISPATCH, onBack: () => {} })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('rally/42-fix-bug'), 'should show branch');
     assert.ok(output.includes('/home/user/projects/repo-a'), 'should show worktree path');
     assert.ok(output.includes('abc123'), 'should show session ID');
   });
 
   it('displays status and changes fields', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: SAMPLE_DISPATCH, onBack: () => {} })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('implementing'), 'should show status');
     assert.ok(output.includes('3 files'), 'should show changes');
   });
 
   it('shows escape hint', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: SAMPLE_DISPATCH, onBack: () => {} })
     );
-    lastCleanup = cleanup;
-    assert.ok(lastFrame().includes('Esc back'), 'should show escape hint');
+    assert.ok(lastInstance.lastFrame().includes('Esc back'), 'should show escape hint');
   });
 
   it('calls onBack when Escape is pressed', async () => {
     let backCalled = false;
-    const { stdin, lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: SAMPLE_DISPATCH, onBack: () => { backCalled = true; } })
     );
-    lastCleanup = cleanup;
     await delay();
-    stdin.write('\x1B');
+    lastInstance.stdin.write('\x1B');
     await delay();
     assert.ok(backCalled, 'should call onBack on Escape');
   });
@@ -91,11 +90,10 @@ describe('DetailView', () => {
       number: 1,
       status: 'planning',
     };
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DetailView, { dispatch: minimalDispatch, onBack: () => {} })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('—'), 'should show dash for missing fields');
   });
 });

--- a/test/ui/DispatchTable.test.js
+++ b/test/ui/DispatchTable.test.js
@@ -5,8 +5,13 @@ import { render } from 'ink-testing-library';
 import DispatchTable, { STATUS_ICONS, computeColumnWidths } from '../../lib/ui/components/DispatchTable.js';
 import { formatAge, groupByProject } from '../../lib/ui/dashboard-data.js';
 
-let lastCleanup;
-afterEach(() => { if (lastCleanup) lastCleanup(); });
+let lastInstance;
+afterEach(() => {
+  if (lastInstance) {
+    lastInstance.unmount();
+    lastInstance.cleanup();
+  }
+});
 
 const SAMPLE_DISPATCHES = [
   {
@@ -33,11 +38,10 @@ const SAMPLE_DISPATCHES = [
 
 describe('DispatchTable', () => {
   it('renders header columns', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(!output.includes('Project'), 'Project is now a group header, not a column');
     assert.ok(output.includes('Issue/PR'), 'should include Issue/PR column');
     assert.ok(!output.includes('Branch'), 'should not include Branch column');
@@ -47,11 +51,10 @@ describe('DispatchTable', () => {
   });
 
   it('renders dispatch data rows with project group headers', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('owner/repo-a'), 'should include project group header');
     assert.ok(output.includes('owner/repo-b'), 'should include second project group header');
     assert.ok(output.includes('Issue #42'), 'should include issue ref');
@@ -71,11 +74,10 @@ describe('DispatchTable', () => {
       session_id: `s${i}`,
       created: new Date().toISOString(),
     }));
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DispatchTable, { dispatches })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     for (const status of statuses) {
       assert.ok(
         output.includes(STATUS_ICONS[status]),
@@ -89,6 +91,7 @@ describe('DispatchTable', () => {
       React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES, selectedIndex: 0 })
     );
     const selected = r1.lastFrame();
+    r1.unmount();
     r1.cleanup();
     assert.ok(selected.includes('❯'), 'selected row should show arrow indicator');
     assert.ok(selected.includes('owner/repo-a'), 'selected row data should render');
@@ -99,31 +102,30 @@ describe('DispatchTable', () => {
       React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES, selectedIndex: -1 })
     );
     const noSelection = r1.lastFrame();
+    r1.unmount();
     r1.cleanup();
     assert.ok(!noSelection.includes('❯'), 'no arrow should appear when nothing is selected');
     const r2 = render(
       React.createElement(DispatchTable, { dispatches: SAMPLE_DISPATCHES })
     );
     const defaultRender = r2.lastFrame();
-    lastCleanup = r2.cleanup;
+    lastInstance = r2;
     assert.equal(noSelection, defaultRender, 'selectedIndex -1 should match default render');
   });
 
   it('renders empty state when no dispatches', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DispatchTable, { dispatches: [] })
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('No active dispatches'), 'should show empty message');
   });
 
   it('renders empty state with default props', () => {
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(DispatchTable)
     );
-    lastCleanup = cleanup;
-    const output = lastFrame();
+    const output = lastInstance.lastFrame();
     assert.ok(output.includes('No active dispatches'), 'should show empty message');
   });
 });

--- a/test/ui/LogViewer.test.js
+++ b/test/ui/LogViewer.test.js
@@ -4,8 +4,13 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import LogViewer from '../../lib/ui/components/LogViewer.js';
 
-let lastCleanup;
-afterEach(() => { if (lastCleanup) lastCleanup(); });
+let lastInstance;
+afterEach(() => {
+  if (lastInstance) {
+    lastInstance.unmount();
+    lastInstance.cleanup();
+  }
+});
 
 const SAMPLE_DISPATCH = {
   repo: 'owner/repo-a',
@@ -21,7 +26,7 @@ function makeLogContent(lineCount) {
 describe('LogViewer', () => {
   it('shows "No log file available" when logPath missing', () => {
     const dispatch = { ...SAMPLE_DISPATCH, logPath: null };
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(LogViewer, {
         dispatch,
         onBack: () => {},
@@ -29,13 +34,12 @@ describe('LogViewer', () => {
         _existsSync: () => false,
       })
     );
-    lastCleanup = cleanup;
-    assert.ok(lastFrame().includes('No log file available'));
+    assert.ok(lastInstance.lastFrame().includes('No log file available'));
   });
 
   it('starts scrolled to the bottom for long logs', () => {
     const content = makeLogContent(50);
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(LogViewer, {
         dispatch: SAMPLE_DISPATCH,
         onBack: () => {},
@@ -44,8 +48,7 @@ describe('LogViewer', () => {
         _existsSync: () => true,
       })
     );
-    lastCleanup = cleanup;
-    const frame = lastFrame();
+    const frame = lastInstance.lastFrame();
     // Should show the last lines, not the first
     assert.ok(frame.includes('line-50'), 'should show last line');
     assert.ok(!frame.includes('line-1\n'), 'should not show first line at top');
@@ -53,7 +56,7 @@ describe('LogViewer', () => {
 
   it('renders escape hint in footer', () => {
     const content = makeLogContent(5);
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(LogViewer, {
         dispatch: SAMPLE_DISPATCH,
         onBack: () => {},
@@ -61,14 +64,13 @@ describe('LogViewer', () => {
         _existsSync: () => true,
       })
     );
-    lastCleanup = cleanup;
-    assert.ok(lastFrame().includes('Esc back'), 'should show escape hint');
-    assert.ok(lastFrame().includes('scroll'), 'should show scroll hint');
+    assert.ok(lastInstance.lastFrame().includes('Esc back'), 'should show escape hint');
+    assert.ok(lastInstance.lastFrame().includes('scroll'), 'should show scroll hint');
   });
 
   it('shows short logs without scrolling', () => {
     const content = makeLogContent(5);
-    const { lastFrame, cleanup } = render(
+    lastInstance = render(
       React.createElement(LogViewer, {
         dispatch: SAMPLE_DISPATCH,
         onBack: () => {},
@@ -77,8 +79,7 @@ describe('LogViewer', () => {
         _existsSync: () => true,
       })
     );
-    lastCleanup = cleanup;
-    const frame = lastFrame();
+    const frame = lastInstance.lastFrame();
     assert.ok(frame.includes('line-1'));
     assert.ok(frame.includes('line-5'));
   });


### PR DESCRIPTION
## Summary

Fixes #299 — UI tests had incomplete cleanup of ink-testing-library render instances.

## What changed

**4 test files fixed:**
- **Dashboard.test.js**: Added `instance.cleanup()` after `instance.unmount()`
- **DetailView.test.js**: Replaced `cleanup()`-only pattern with full `unmount() + cleanup()`
- **DispatchTable.test.js**: Same — both `unmount()` and `cleanup()` now called on every render
- **LogViewer.test.js**: Same pattern fix

**No changes needed:**
- DispatchBox.test.js and StatusMessage.test.js already used the global `cleanup()` from ink-testing-library which calls both.

## Investigation findings

The issue assumed test code was leaking resources. After thorough investigation:

1. **Test cleanup was genuinely incomplete** — some files called `unmount()` without `cleanup()` and vice versa. This leaked Ink instances, signal handlers (`useInput`, `useApp`), and React reconciler state between tests. **Fixed.**

2. **`--test-force-exit` is still required** — even with perfect cleanup, importing Ink causes a ~35-second process exit delay per test file. Root cause: Ink depends on `es-toolkit/compat` (v1.44.0), which creates a massive ESM module graph. Node.js takes 30-60 seconds to clean up these module objects on exit. This is not a test code leak — it's an upstream dependency characteristic.

   Without `--test-force-exit`, the 6 UI test files would add 3-5 minutes of idle wait time to the test suite.

## Verification

All 82 UI tests pass (0 failures) with the cleanup fixes applied.