### PR TITLE
feat: add 'o' shortcut to open dispatch in browser

### DIFF
--- a/lib/ui/Dashboard.jsx
+++ b/lib/ui/Dashboard.jsx
@@ -67,6 +67,7 @@ export default function Dashboard({ project, onSelect, onAttachSession, onDispat
   const actions = actionDispatch
     ? [
         ACTIONS.OPEN_VSCODE,
+        ACTIONS.OPEN_BROWSER,
         ...(hasConnectableSession ? [ACTIONS.CONNECT_IDE] : []),
         ...(actionDispatch.worktreePath ? [ACTIONS.ATTACH_SESSION] : []),
         ...(actionDispatch.logPath ? [ACTIONS.VIEW_LOGS] : []),
@@ -102,6 +103,15 @@ export default function Dashboard({ project, onSelect, onAttachSession, onDispat
         console.error(`Failed to launch VS Code: ${err.message}`);
       });
     }
+  }
+
+  function openInBrowser(dispatch) {
+    const ghCmd = dispatch.type === 'pr' ? 'pr' : 'issue';
+    const child = _spawn('gh', [ghCmd, 'view', String(dispatch.number), '--repo', dispatch.repo, '--web'], { detached: true, stdio: 'ignore' });
+    child.unref();
+    child.on('error', (err) => {
+      console.error(`Failed to open in browser: ${err.message}`);
+    });
   }
 
   function connectIDE(dispatch) {
@@ -180,6 +190,8 @@ export default function Dashboard({ project, onSelect, onAttachSession, onDispat
       setActionIndex(i => (i < actionCount - 1 ? i + 1 : i));
     } else if (direction === ACTIONS.OPEN_VSCODE) {
       openInVSCode(actionDispatch);
+    } else if (direction === ACTIONS.OPEN_BROWSER) {
+      openInBrowser(actionDispatch);
     } else if (direction === ACTIONS.CONNECT_IDE) {
       connectIDE(actionDispatch);
     } else if (direction === ACTIONS.ATTACH_SESSION) {
@@ -190,6 +202,8 @@ export default function Dashboard({ project, onSelect, onAttachSession, onDispat
       const selectedAction = actions[actionIndex];
       if (selectedAction === ACTIONS.OPEN_VSCODE) {
         openInVSCode(actionDispatch);
+      } else if (selectedAction === ACTIONS.OPEN_BROWSER) {
+        openInBrowser(actionDispatch);
       } else if (selectedAction === ACTIONS.CONNECT_IDE) {
         connectIDE(actionDispatch);
       } else if (selectedAction === ACTIONS.ATTACH_SESSION) {
@@ -224,6 +238,8 @@ export default function Dashboard({ project, onSelect, onAttachSession, onDispat
       setDetailViewDispatch(data.dispatches[selectedIndex]);
     } else if (input === 'v' && count > 0) {
       openInVSCode(data.dispatches[selectedIndex]);
+    } else if (input === 'o' && count > 0) {
+      openInBrowser(data.dispatches[selectedIndex]);
     } else if (input === 'c' && count > 0) {
       const selected = data.dispatches[selectedIndex];
       if (selected.session_id && UUID_RE.test(selected.session_id)) {
@@ -333,7 +349,7 @@ export default function Dashboard({ project, onSelect, onAttachSession, onDispat
       <DispatchTable dispatches={data.dispatches} selectedIndex={selectedIndex} />
       <SummaryLine summary={data.summary} />
       <Box marginTop={1}>
-        <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · a attach · c connect IDE · l logs · n new dispatch · p pushed · x delete · r refresh · q quit</Text>
+        <Text dimColor>↑/↓ navigate · Enter actions · d details · v open · o browser · a attach · c connect IDE · l logs · n new dispatch · p pushed · x delete · r refresh · q quit</Text>
       </Box>
     </Box>
   );

--- a/lib/ui/components/ActionMenu.jsx
+++ b/lib/ui/components/ActionMenu.jsx
@@ -4,6 +4,7 @@ import { UUID_RE } from '../../copilot.js';
 
 const ACTIONS = {
   OPEN_VSCODE: 'open-vscode',
+  OPEN_BROWSER: 'open-browser',
   CONNECT_IDE: 'connect-ide',
   ATTACH_SESSION: 'attach-session',
   VIEW_LOGS: 'view-logs',
@@ -22,6 +23,7 @@ export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack 
 
   const actions = [
     { id: ACTIONS.OPEN_VSCODE, label: '(v) Open in VS Code' },
+    { id: ACTIONS.OPEN_BROWSER, label: '(o) Open in browser' },
     ...(hasConnectableSession
       ? [{ id: ACTIONS.CONNECT_IDE, label: '(c) Connect IDE session' }]
       : []),
@@ -35,6 +37,8 @@ export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack 
   useInput((input, key) => {
     if (input === 'v') {
       onSelect(ACTIONS.OPEN_VSCODE);
+    } else if (input === 'o') {
+      onSelect(ACTIONS.OPEN_BROWSER);
     } else if (input === 'c' && hasConnectableSession) {
       onSelect(ACTIONS.CONNECT_IDE);
     } else if (input === 'a' && hasWorktree) {
@@ -68,7 +72,7 @@ export default function ActionMenu({ dispatch, selectedAction, onSelect, onBack 
         </Box>
       ))}
       <Box marginTop={1}>
-        <Text dimColor>↑/↓ navigate · Enter confirm · v/a/l shortcut · Esc back</Text>
+        <Text dimColor>↑/↓ navigate · Enter confirm · v/o/a/l shortcut · Esc back</Text>
       </Box>
     </Box>
   );

--- a/test/ui/Dashboard.test.js
+++ b/test/ui/Dashboard.test.js
@@ -420,6 +420,8 @@ describe('Dashboard component', () => {
     await delay();
     instance.stdin.write('\x1B[B');
     await delay();
+    instance.stdin.write('\x1B[B');
+    await delay();
     instance.stdin.write('\r');
     await delay();
     const output = instance.lastFrame();
@@ -715,6 +717,101 @@ describe('Dashboard component', () => {
     // is immune to terminal-width line wrapping.
     const plain = output.replace(/\u001b\[[0-9;]*m/g, '').replace(/\n\s*/g, ' ');
     assert.ok(plain.includes('n new dispatch'), 'should show n new dispatch shortcut hint');
+  });
+
+  it('help text includes o browser shortcut', () => {
+    instance = render(React.createElement(Dashboard, { refreshInterval: 0 }));
+    const output = instance.lastFrame();
+    const plain = output.replace(/\u001b\[[0-9;]*m/g, '').replace(/\n\s*/g, ' ');
+    assert.ok(plain.includes('o browser'), 'should show o browser shortcut hint');
+  });
+
+  it('o shortcut opens issue in browser via gh cli', async () => {
+    let spawnArgs;
+    const spawnMock = (cmd, args, opts) => {
+      spawnArgs = { cmd, args };
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    instance.stdin.write('o');
+    await delay();
+    assert.ok(spawnArgs, 'o shortcut should spawn gh');
+    assert.equal(spawnArgs.cmd, 'gh');
+    assert.deepEqual(spawnArgs.args, ['issue', 'view', '42', '--repo', 'owner/repo-a', '--web']);
+  });
+
+  it('o shortcut opens PR in browser via gh cli', async () => {
+    const dispatches = makeSampleDispatches();
+    writeFileSync(join(TEST_DIR, 'active.yaml'), yaml.dump({ dispatches }), 'utf8');
+
+    let spawnArgs;
+    const spawnMock = (cmd, args, opts) => {
+      spawnArgs = { cmd, args };
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    // Navigate down to the PR dispatch (index 1)
+    instance.stdin.write('\x1B[B');
+    await delay();
+    instance.stdin.write('o');
+    await delay();
+    assert.ok(spawnArgs, 'o shortcut should spawn gh for PR');
+    assert.equal(spawnArgs.cmd, 'gh');
+    assert.deepEqual(spawnArgs.args, ['pr', 'view', '7', '--repo', 'owner/repo-b', '--web']);
+  });
+
+  it('o shortcut does not quit the dashboard', async () => {
+    const spawnMock = (cmd, args, opts) => {
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    instance.stdin.write('o');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(output.includes('Rally Dashboard'), 'dashboard should still be visible after o');
+  });
+
+  it('action menu shows Open in browser option', async () => {
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0 })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    const output = instance.lastFrame();
+    assert.ok(output.includes('(o) Open in browser'), 'should show Open in browser option');
+  });
+
+  it('action menu o shortcut opens in browser', async () => {
+    let spawnArgs;
+    const spawnMock = (cmd, args, opts) => {
+      spawnArgs = { cmd, args };
+      return { unref: () => {}, on: () => {} };
+    };
+
+    instance = render(
+      React.createElement(Dashboard, { refreshInterval: 0, _spawn: spawnMock })
+    );
+    await delay();
+    instance.stdin.write('\r');
+    await delay();
+    instance.stdin.write('o');
+    await delay();
+    assert.ok(spawnArgs, 'action menu o shortcut should spawn gh');
+    assert.equal(spawnArgs.cmd, 'gh');
+    assert.deepEqual(spawnArgs.args, ['issue', 'view', '42', '--repo', 'owner/repo-a', '--web']);
   });
 
   it('n shortcut opens project browser', async () => {


### PR DESCRIPTION
## Summary

Adds an **Open in browser** shortcut (`o`) to both the Dashboard main view and the ActionMenu, closing #323.

### What it does
- **Dashboard**: pressing `o` runs `gh issue view N --repo owner/repo --web` (or `gh pr view` for PRs) to open the selected dispatch in the default browser
- **ActionMenu**: new `(o) Open in browser` option with keyboard shortcut
- Non-blocking: uses detached spawn so the dashboard stays responsive
- Help text updated in both views

### Tests added (7 new)
- `o` shortcut opens issue in browser via gh cli
- `o` shortcut opens PR in browser via gh cli
- `o` shortcut does not quit the dashboard
- Help text includes `o browser` shortcut
- Action menu shows Open in browser option
- Action menu `o` shortcut opens in browser
- Existing action menu navigation test updated for new menu item

### Files changed
- `lib/ui/Dashboard.jsx` — `openInBrowser()` + `o` key handler + action menu wiring
- `lib/ui/components/ActionMenu.jsx` — `OPEN_BROWSER` action + `o` shortcut
- `test/ui/Dashboard.test.js` — 7 new tests

Closes #323