### PR TITLE
docs: restructure README around dashboard-first experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The dashboard is the primary way to use Rally day-to-day:
 5. **Review:** Press `o` to open the PR in your browser, or `v` to open in VS Code
 6. **Attach:** Press `a` to attach to a running Copilot session if it needs guidance
 
-### For agents (CLI workflow)
+### CLI Workflows
 
 Agents and scripts should use CLI commands directly:
 
@@ -130,7 +130,7 @@ rally dispatch issue 42
 
 ## Dashboard
 
-The dashboard (`rally` or `rally dashboard`) is the primary interface for Rally. It supports interactive (TTY) and plain-text (piped) output.
+The dashboard (`rally dashboard`) is the primary interface for Rally. It supports interactive (TTY) and plain-text (piped) output.
 
 ```
 $ rally dashboard [options]


### PR DESCRIPTION
## Summary

Restructures the README to make the dashboard the primary user experience.

### Changes

- **Quick Start rewritten** — now guides users to `rally` (the dashboard) as the main entry point, with an ASCII visual showing what the dashboard looks like with sample data
- **Workflows section added** — moved up from Common Patterns, split into human (dashboard) and agent (CLI) paths
- **Dashboard section** — dedicated section with the full keyboard shortcuts table
- **Commands section** — reframed as CLI reference for scripts and agents, with a note directing humans to the dashboard
- **Docker Sandbox** — moved from Quick Start into its own section near the end
- **Section order** — Quick Start → Workflows → Dashboard → Commands → Status Model → Key Concepts → Docker Sandbox → Future Work → License