### PR TITLE
refactor: standardize on RallyError for user-facing errors (#348)

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import yaml from 'js-yaml';
 import { readActive, atomicWrite, ensureConfigDir, getConfigDir } from './config.js';
 import { isPidAlive } from './utils.js';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 const VALID_STATUSES = ['planning', 'implementing', 'reviewing', 'pushed', 'done', 'cleaned'];
 
@@ -143,9 +144,9 @@ function acquireLock() {
   }
   const pidInfo = lastAlivePid ? ` (PID ${lastAlivePid})` : '';
   const staleMinutes = Math.ceil(LOCK_STALE_MS / 60000);
-  throw new Error(
+  throw new RallyError(
     `Failed to acquire lock on active.yaml — another rally process${pidInfo} is running. ` +
-    `If this is stale, remove ${lockDir} or wait ${staleMinutes} minutes and retry.`
+    `If this is stale, remove ${lockDir} or wait ${staleMinutes} minutes and retry.`, EXIT_GENERAL
   );
 }
 
@@ -193,7 +194,7 @@ function writeActiveAtomic(data) {
  */
 function validateStatus(status) {
   if (!VALID_STATUSES.includes(status)) {
-    throw new Error(`Invalid dispatch status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}`);
+    throw new RallyError(`Invalid dispatch status: "${status}". Must be one of: ${VALID_STATUSES.join(', ')}`, EXIT_GENERAL);
   }
 }
 
@@ -207,12 +208,12 @@ function validateStatus(status) {
 export function addDispatch(record) {
   for (const field of REQUIRED_FIELDS) {
     if (record[field] === undefined || record[field] === null) {
-      throw new Error(`Missing required field: ${field}`);
+      throw new RallyError(`Missing required field: ${field}`, EXIT_GENERAL);
     }
   }
 
   if (record.type !== 'issue' && record.type !== 'pr') {
-    throw new Error(`Invalid dispatch type: "${record.type}". Must be "issue" or "pr"`);
+    throw new RallyError(`Invalid dispatch type: "${record.type}". Must be "issue" or "pr"`, EXIT_GENERAL);
   }
 
   validateStatus(record.status);
@@ -221,7 +222,7 @@ export function addDispatch(record) {
     const data = readActive();
     const existing = data.dispatches.find(d => d.id === record.id);
     if (existing) {
-      throw new Error(`Dispatch with id "${record.id}" already exists`);
+      throw new RallyError(`Dispatch with id "${record.id}" already exists`, EXIT_GENERAL);
     }
 
     const dispatch = {
@@ -250,7 +251,7 @@ export function updateDispatchStatus(id, status) {
     const data = readActive();
     const dispatch = data.dispatches.find(d => d.id === id);
     if (!dispatch) {
-      throw new Error(`Dispatch with id "${id}" not found`);
+      throw new RallyError(`Dispatch with id "${id}" not found`, EXIT_GENERAL);
     }
 
     dispatch.status = status;
@@ -272,14 +273,14 @@ const UPDATABLE_FIELDS = ['session_id', 'status', 'logPath', 'pid'];
 
 export function updateDispatchField(id, field, value) {
   if (!UPDATABLE_FIELDS.includes(field)) {
-    throw new Error(`Cannot update field: "${field}"`);
+    throw new RallyError(`Cannot update field: "${field}"`, EXIT_GENERAL);
   }
   if (field === 'status') validateStatus(value);
   return withLock(() => {
     const data = readActive();
     const dispatch = data.dispatches.find(d => d.id === id);
     if (!dispatch) {
-      throw new Error(`Dispatch with id "${id}" not found`);
+      throw new RallyError(`Dispatch with id "${id}" not found`, EXIT_GENERAL);
     }
 
     dispatch[field] = value;
@@ -300,7 +301,7 @@ export function removeDispatch(id) {
     const data = readActive();
     const index = data.dispatches.findIndex(d => d.id === id);
     if (index === -1) {
-      throw new Error(`Dispatch with id "${id}" not found`);
+      throw new RallyError(`Dispatch with id "${id}" not found`, EXIT_GENERAL);
     }
 
     const [removed] = data.dispatches.splice(index, 1);

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { join, dirname, basename, isAbsolute, resolve, sep } from 'node:path';
 import yaml from 'js-yaml';
 import { DEFAULT_DENY_TOOLS } from './copilot.js';
+import { RallyError, EXIT_CONFIG } from './errors.js';
 
 
 export function atomicWrite(filePath, content) {
@@ -21,7 +22,7 @@ export function atomicWrite(filePath, content) {
 export function getConfigDir() {
   if (process.env.RALLY_HOME) {
     if (!isAbsolute(process.env.RALLY_HOME)) {
-      throw new Error(`RALLY_HOME must be an absolute path, got: "${process.env.RALLY_HOME}"`);
+      throw new RallyError(`RALLY_HOME must be an absolute path, got: "${process.env.RALLY_HOME}"`, EXIT_CONFIG);
     }
     return process.env.RALLY_HOME;
   }
@@ -43,7 +44,7 @@ export function ensureConfigDir() {
   } else if (process.platform !== 'win32') {
     const stat = statSync(configDir);
     if (!stat.isDirectory()) {
-      throw new Error(`Config path exists but is not a directory: ${configDir}`);
+      throw new RallyError(`Config path exists but is not a directory: ${configDir}`, EXIT_CONFIG);
     }
     chmodSync(configDir, 0o700);
   }
@@ -59,7 +60,7 @@ export function readConfig() {
     const content = readFileSync(configPath, 'utf8');
     return yaml.load(content, { schema: yaml.CORE_SCHEMA });
   } catch (err) {
-    throw new Error(`Failed to parse config.yaml: ${err.message}`);
+    throw new RallyError(`Failed to parse config.yaml: ${err.message}`, EXIT_CONFIG);
   }
 }
 
@@ -79,7 +80,7 @@ export function readProjects() {
     const content = readFileSync(projectsPath, 'utf8');
     return yaml.load(content, { schema: yaml.CORE_SCHEMA }) ?? { projects: [] };
   } catch (err) {
-    throw new Error(`Failed to parse projects.yaml: ${err.message}`);
+    throw new RallyError(`Failed to parse projects.yaml: ${err.message}`, EXIT_CONFIG);
   }
 }
 
@@ -99,7 +100,7 @@ export function readActive() {
     const content = readFileSync(activePath, 'utf8');
     return yaml.load(content, { schema: yaml.CORE_SCHEMA }) ?? { dispatches: [] };
   } catch (err) {
-    throw new Error(`Failed to parse active.yaml: ${err.message}`);
+    throw new RallyError(`Failed to parse active.yaml: ${err.message}`, EXIT_CONFIG);
   }
 }
 
@@ -119,13 +120,13 @@ const VALID_TRISTATE = ['always', 'never', 'ask'];
 function validateDenyTools(value, fieldName) {
   if (value == null) return [...DEFAULT_DENY_TOOLS];
   if (!Array.isArray(value)) {
-    throw new Error(`Invalid ${fieldName}: must be an array of strings`);
+    throw new RallyError(`Invalid ${fieldName}: must be an array of strings`, EXIT_CONFIG);
   }
   if (value.length === 0) {
-    throw new Error(`Invalid ${fieldName}: must not be empty (would bypass all tool restrictions)`);
+    throw new RallyError(`Invalid ${fieldName}: must not be empty (would bypass all tool restrictions)`, EXIT_CONFIG);
   }
   if (!value.every(t => typeof t === 'string')) {
-    throw new Error(`Invalid ${fieldName}: must be an array of strings`);
+    throw new RallyError(`Invalid ${fieldName}: must be an array of strings`, EXIT_CONFIG);
   }
   return value;
 }
@@ -137,15 +138,15 @@ function validateDenyTools(value, fieldName) {
 function validateReviewTemplate(value) {
   if (value == null || value === '') return null;
   if (typeof value !== 'string') {
-    throw new Error('Invalid review_template: must be a string path or null');
+    throw new RallyError('Invalid review_template: must be a string path or null', EXIT_CONFIG);
   }
   if (isAbsolute(value)) {
-    throw new Error('Invalid review_template: must be a relative path (resolved from config directory)');
+    throw new RallyError('Invalid review_template: must be a relative path (resolved from config directory)', EXIT_CONFIG);
   }
   const configDir = getConfigDir();
   const resolved = resolve(configDir, value);
   if (!resolved.startsWith(configDir + sep) && resolved !== configDir) {
-    throw new Error('Invalid review_template: path must not traverse outside config directory');
+    throw new RallyError('Invalid review_template: path must not traverse outside config directory', EXIT_CONFIG);
   }
   return value;
 }
@@ -172,10 +173,10 @@ export function getSettings() {
   const dockerSandbox = settings.docker_sandbox || 'ask';
   const requireTrust = settings.require_trust || 'ask';
   if (!VALID_TRISTATE.includes(dockerSandbox)) {
-    throw new Error(`Invalid docker_sandbox value: "${dockerSandbox}". Must be one of: ${VALID_TRISTATE.join(', ')}`);
+    throw new RallyError(`Invalid docker_sandbox value: "${dockerSandbox}". Must be one of: ${VALID_TRISTATE.join(', ')}`, EXIT_CONFIG);
   }
   if (!VALID_TRISTATE.includes(requireTrust)) {
-    throw new Error(`Invalid require_trust value: "${requireTrust}". Must be one of: ${VALID_TRISTATE.join(', ')}`);
+    throw new RallyError(`Invalid require_trust value: "${requireTrust}". Must be one of: ${VALID_TRISTATE.join(', ')}`, EXIT_CONFIG);
   }
   const rawCopilot = settings.deny_tools_copilot;
   const rawSandbox = settings.deny_tools_sandbox;
@@ -199,6 +200,6 @@ export function validateOnboarded(repo) {
   const match = projectList.find((p) => p.repo === repo) ||
                 projectList.find((p) => p.name === repoName);
   if (!match) {
-    throw new Error(`Repository "${repo}" is not onboarded. Run: rally onboard ${repo}`);
+    throw new RallyError(`Repository "${repo}" is not onboarded. Run: rally onboard ${repo}`, EXIT_CONFIG);
   }
 }

--- a/lib/dispatch-core.js
+++ b/lib/dispatch-core.js
@@ -7,6 +7,7 @@ import { addDispatch } from './active.js';
 import { validateOnboarded } from './config.js';
 import { launchCopilot, checkCopilotAvailable, checkDockerSandboxAvailable } from './copilot.js';
 import { slugify } from './utils.js';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 /**
  * Validate common dispatch inputs.
@@ -14,18 +15,18 @@ import { slugify } from './utils.js';
  */
 export function validateDispatchInputs({ itemNumber, repo, repoPath, itemLabel = 'item' }) {
   if (!itemNumber) {
-    throw new Error(`${itemLabel} number is required`);
+    throw new RallyError(`${itemLabel} number is required`, EXIT_GENERAL);
   }
   if (!repo) {
-    throw new Error('Repository (owner/repo) is required');
+    throw new RallyError('Repository (owner/repo) is required', EXIT_GENERAL);
   }
   const repoParts = repo.split('/');
   if (repoParts.length !== 2 || !repoParts[0] || !repoParts[1]) {
-    throw new Error('Repository must be in "owner/repo" format');
+    throw new RallyError('Repository must be in "owner/repo" format', EXIT_GENERAL);
   }
   const repoName = repoParts[1];
   if (!repoPath) {
-    throw new Error('Repository path is required');
+    throw new RallyError('Repository path is required', EXIT_GENERAL);
   }
 
   validateOnboarded(repo);
@@ -33,7 +34,7 @@ export function validateDispatchInputs({ itemNumber, repo, repoPath, itemLabel =
   const resolvedRepoPath = resolve(repoPath);
   const number = Number(itemNumber);
   if (!Number.isInteger(number) || number <= 0) {
-    throw new Error(`Invalid ${itemLabel} number: "${itemNumber}". Must be a positive integer.`);
+    throw new RallyError(`Invalid ${itemLabel} number: "${itemNumber}". Must be a positive integer.`, EXIT_GENERAL);
   }
 
   return { number, repoName, resolvedRepoPath };
@@ -135,8 +136,8 @@ export function setupDispatchWorktree(opts) {
     // Launch Copilot CLI (if available)
     if (sandbox) {
       if (!checkDockerSandboxAvailable({ _exec })) {
-        throw new Error(
-          'Docker sandbox not available — install Docker Desktop 4.58+ with sandbox support or remove --sandbox'
+        throw new RallyError(
+          'Docker sandbox not available — install Docker Desktop 4.58+ with sandbox support or remove --sandbox', EXIT_GENERAL
         );
       }
       // In sandbox mode, surface all spawn errors — user explicitly requested it

--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -6,6 +6,7 @@ import { slugify } from './utils.js';
 import { validateDispatchInputs, warnUncommittedChanges, setupDispatchWorktree } from './dispatch-core.js';
 import { checkDispatchTrust } from './dispatch-trust.js';
 import { assertTools } from './tools.js';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 /**
  * Dispatch an issue: full workflow.
@@ -70,9 +71,9 @@ export async function dispatchIssue(options = {}) {
     issue = JSON.parse(output);
   } catch (error) {
     if (error.message && error.message.includes('Could not resolve to an Issue')) {
-      throw new Error(`Issue #${number} not found in ${repo}`);
+      throw new RallyError(`Issue #${number} not found in ${repo}`, EXIT_GENERAL);
     }
-    throw new Error(`Failed to fetch issue #${number}: ${error.message}`);
+    throw new RallyError(`Failed to fetch issue #${number}: ${error.message}`, EXIT_GENERAL);
   }
 
   // Create branch name

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -7,6 +7,7 @@ import { slugify } from './utils.js';
 import { validateDispatchInputs, warnUncommittedChanges, setupDispatchWorktree } from './dispatch-core.js';
 import { checkDispatchTrust } from './dispatch-trust.js';
 import { assertTools } from './tools.js';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 /**
  * Sanitize a git ref name for safe interpolation into prompts.
@@ -150,16 +151,16 @@ export function fetchPrOrFail(number, repo, _exec = execFileSync) {
     pr = JSON.parse(output);
   } catch (error) {
     if (error.message && error.message.includes('Could not resolve to a PullRequest')) {
-      throw new Error(`PR #${number} not found in ${repo}`);
+      throw new RallyError(`PR #${number} not found in ${repo}`, EXIT_GENERAL);
     }
-    throw new Error(`Failed to fetch PR #${number}: ${error.message}`);
+    throw new RallyError(`Failed to fetch PR #${number}: ${error.message}`, EXIT_GENERAL);
   }
 
   if (pr.state === 'MERGED') {
-    throw new Error(`PR #${number} is already merged`);
+    throw new RallyError(`PR #${number} is already merged`, EXIT_GENERAL);
   }
   if (pr.state === 'CLOSED') {
-    throw new Error(`PR #${number} is closed`);
+    throw new RallyError(`PR #${number} is closed`, EXIT_GENERAL);
   }
 
   return pr;
@@ -214,7 +215,7 @@ export async function dispatchPr(options = {}) {
 
   // Validate custom prompt file early
   if (promptFile && !existsSync(promptFile)) {
-    throw new Error(`Custom prompt file not found: ${promptFile}`);
+    throw new RallyError(`Custom prompt file not found: ${promptFile}`, EXIT_GENERAL);
   }
 
   const { number, repoName, resolvedRepoPath } = validateDispatchInputs({
@@ -275,12 +276,12 @@ export async function dispatchPr(options = {}) {
       try {
         _exec('git', ['fetch', 'origin', `refs/pull/${number}/head`], { cwd: wtPath, encoding: 'utf8', stdio: 'pipe' });
       } catch (err) {
-        throw new Error(`Failed to fetch PR #${number} head ref: ${err.message}`);
+        throw new RallyError(`Failed to fetch PR #${number} head ref: ${err.message}`, EXIT_GENERAL);
       }
       try {
         _exec('git', ['reset', '--hard', 'FETCH_HEAD'], { cwd: wtPath, encoding: 'utf8', stdio: 'pipe' });
       } catch (err) {
-        throw new Error(`Failed to reset worktree to PR #${number} head: ${err.message}`);
+        throw new RallyError(`Failed to reset worktree to PR #${number} head: ${err.message}`, EXIT_GENERAL);
       }
     },
     postSymlinkFn: (wtPath) => {

--- a/lib/onboard.js
+++ b/lib/onboard.js
@@ -7,6 +7,7 @@ import { createSymlink } from './symlink.js';
 import { addExcludes, getExcludeEntries } from './exclude.js';
 import { selectTeam } from './team.js';
 import { parseGitHubRemoteUrl } from './github-url.js';
+import { RallyError, EXIT_CONFIG } from './errors.js';
 
 /**
  * Parse a GitHub URL or owner/repo shorthand into clone metadata.
@@ -37,13 +38,13 @@ export function parseForkArg(fork) {
   if (!fork) return null;
   const match = fork.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
   if (!match) {
-    throw new Error(`Invalid --fork format: "${fork}". Expected owner/repo (e.g. myuser/myrepo).`);
+    throw new RallyError(`Invalid --fork format: "${fork}". Expected owner/repo (e.g. myuser/myrepo).`, EXIT_CONFIG);
   }
   const owner = match[1];
   const repo = match[2];
   if (owner.includes('..') || repo.includes('..') || owner === '.' || repo === '.') {
-    throw new Error(
-      `Invalid --fork value: "${fork}". Owner and repo must not contain '..' or be '.'.`
+    throw new RallyError(
+      `Invalid --fork value: "${fork}". Owner and repo must not contain '..' or be '.'.`, EXIT_CONFIG
     );
   }
   return { owner, repo };
@@ -78,7 +79,7 @@ export function configureForkRemotes(projectPath, fork, _exec) {
       exec(['remote', 'rename', 'origin', 'upstream']);
       console.log(chalk.green('✓') + ` Renamed origin → upstream`);
     } catch {
-      throw new Error('Failed to rename origin to upstream. Does the repo have an origin remote?');
+      throw new RallyError('Failed to rename origin to upstream. Does the repo have an origin remote?', EXIT_CONFIG);
     }
   }
 
@@ -142,11 +143,11 @@ function cloneOrValidateExisting(parsed, options) {
         const remoteInfo = parseGitHubRemoteUrl(remoteUrl);
         if (remoteInfo) {
           if (remoteInfo.owner !== parsed.owner || remoteInfo.repo !== parsed.repo) {
-            throw new Error(
+            throw new RallyError(
               `Clone target "${cloneTarget}" already exists but belongs to a different repository.\n` +
               `  Expected: ${parsed.owner}/${parsed.repo}\n` +
               `  Found:    ${remoteUrl}\n` +
-              `  Remove the directory or use a different path.`
+              `  Remove the directory or use a different path.`, EXIT_CONFIG
             );
           }
         }
@@ -158,8 +159,8 @@ function cloneOrValidateExisting(parsed, options) {
       }
       // Otherwise, it's a git command failure (not a git repo, no remote, etc.)
       const errorDetails = err.stderr || err.message || 'Unknown error';
-      throw new Error(
-        `Clone target "${cloneTarget}" exists but is not a valid git repository with a remote: ${errorDetails}`
+      throw new RallyError(
+        `Clone target "${cloneTarget}" exists but is not a valid git repository with a remote: ${errorDetails}`, EXIT_CONFIG
       );
     }
     console.log(`  Clone target already exists — skipping clone: ${cloneTarget}`);
@@ -170,7 +171,7 @@ function cloneOrValidateExisting(parsed, options) {
       clone(parsed.cloneUrl, cloneTarget);
     } catch (err) {
       const msg = err.stderr ? err.stderr.toString().trim() : err.message;
-      throw new Error(`Clone failed: ${msg}`);
+      throw new RallyError(`Clone failed: ${msg}`, EXIT_CONFIG);
     }
     console.log(chalk.green('✓') + ` Cloned ${parsed.owner}/${parsed.repo}`);
   }
@@ -187,7 +188,7 @@ function cloneOrValidateExisting(parsed, options) {
 function resolveGitDir(projectPath) {
   const gitCheck = join(projectPath, '.git');
   if (!existsSync(gitCheck)) {
-    throw new Error('Not a git repository. Run from inside a repo or provide a path to one.');
+    throw new RallyError('Not a git repository. Run from inside a repo or provide a path to one.', EXIT_CONFIG);
   }
 
   try {
@@ -197,7 +198,7 @@ function resolveGitDir(projectPath) {
     }).trim();
     return resolve(projectPath, raw);
   } catch {
-    throw new Error('Failed to resolve git directory. Is this a valid git repository?');
+    throw new RallyError('Failed to resolve git directory. Is this a valid git repository?', EXIT_CONFIG);
   }
 }
 
@@ -358,8 +359,8 @@ export async function onboard(options = {}) {
 
   // Validate that --fork without path resolves to a GitHub URL
   if (forkWithoutPath && !parseGithubUrl(input)) {
-    throw new Error(
-      `Invalid --fork value: "${options.fork}". Expected a GitHub owner/repo (e.g. hyperlight-dev/hyperlight-wasm).`
+    throw new RallyError(
+      `Invalid --fork value: "${options.fork}". Expected a GitHub owner/repo (e.g. hyperlight-dev/hyperlight-wasm).`, EXIT_CONFIG
     );
   }
 
@@ -386,9 +387,9 @@ export async function onboard(options = {}) {
         username = exec('gh', ['api', 'user', '--jq', '.login'], { encoding: 'utf8', stdio: 'pipe' }).trim();
       } catch (err) {
         const detail = err && err.message ? ` ${err.message}` : '';
-        throw new Error(
+        throw new RallyError(
           'Failed to determine GitHub username. ' +
-          'Ensure gh CLI is installed and authenticated (gh auth login).' + detail
+          'Ensure gh CLI is installed and authenticated (gh auth login).' + detail, EXIT_CONFIG
         );
       }
       forkInfo = configureForkRemotes(projectPath, `${username}/${parsed.repo}`, options._exec);

--- a/lib/picker.js
+++ b/lib/picker.js
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { select } from '@inquirer/prompts';
 import { readProjects } from './config.js';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 const PICKER_FETCH_LIMIT = '20';
 
@@ -31,7 +32,7 @@ export function fetchIssues(repo, _exec = execFileSync) {
     );
     return JSON.parse(output);
   } catch (err) {
-    throw new Error(`Failed to fetch issues for ${repo}: ${err.message}`);
+    throw new RallyError(`Failed to fetch issues for ${repo}: ${err.message}`, EXIT_GENERAL);
   }
 }
 
@@ -50,7 +51,7 @@ export function fetchPrs(repo, _exec = execFileSync) {
     );
     return JSON.parse(output);
   } catch (err) {
-    throw new Error(`Failed to fetch PRs for ${repo}: ${err.message}`);
+    throw new RallyError(`Failed to fetch PRs for ${repo}: ${err.message}`, EXIT_GENERAL);
   }
 }
 
@@ -86,7 +87,7 @@ export async function pickRepo(opts = {}) {
   const _sel = opts._select || select;
   const projects = listOnboardedRepos(opts);
   if (projects.length === 0) {
-    throw new Error('No projects onboarded. Run: rally onboard <path-or-url>');
+    throw new RallyError('No projects onboarded. Run: rally onboard <path-or-url>', EXIT_GENERAL);
   }
   if (projects.length === 1) {
     return projects[0];
@@ -113,7 +114,7 @@ export async function pickIssue(repo, opts = {}) {
   const _sel = opts._select || select;
   const issues = fetchIssues(repo, opts._exec);
   if (issues.length === 0) {
-    throw new Error(`No open issues found in ${repo}`);
+    throw new RallyError(`No open issues found in ${repo}`, EXIT_GENERAL);
   }
   return _sel({
     message: `Select an issue from ${repo}:`,
@@ -136,7 +137,7 @@ export async function pickPr(repo, opts = {}) {
   const _sel = opts._select || select;
   const prs = fetchPrs(repo, opts._exec);
   if (prs.length === 0) {
-    throw new Error(`No open PRs found in ${repo}`);
+    throw new RallyError(`No open PRs found in ${repo}`, EXIT_GENERAL);
   }
   return _sel({
     message: `Select a PR from ${repo}:`,

--- a/lib/worktree.js
+++ b/lib/worktree.js
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import path from 'node:path';
+import { RallyError, EXIT_GENERAL } from './errors.js';
 
 /**
  * Resolves a path to its canonical form, handling Windows short paths
@@ -52,8 +53,8 @@ export function createWorktree(repoPath, worktreePath, branchName) {
       raceErr.code = 'WORKTREE_EXISTS';
       throw raceErr;
     }
-    throw new Error(
-      `Failed to create worktree at ${absoluteWorktreePath}: ${error.message}`
+    throw new RallyError(
+      `Failed to create worktree at ${absoluteWorktreePath}: ${error.message}`, EXIT_GENERAL
     );
   }
 }
@@ -82,8 +83,8 @@ export function removeWorktree(repoPath, worktreePath, opts = {}) {
         encoding: 'utf8',
       });
       if (status && status.trim().length > 0) {
-        throw new Error(
-          `Worktree at ${absoluteWorktreePath} has uncommitted changes. Pass { force: true } to remove anyway.`
+        throw new RallyError(
+          `Worktree at ${absoluteWorktreePath} has uncommitted changes. Pass { force: true } to remove anyway.`, EXIT_GENERAL
         );
       }
     } catch (err) {
@@ -99,8 +100,8 @@ export function removeWorktree(repoPath, worktreePath, opts = {}) {
   try {
     exec('git', args, { cwd: absoluteRepoPath, encoding: 'utf8' });
   } catch (error) {
-    throw new Error(
-      `Failed to remove worktree at ${absoluteWorktreePath}: ${error.message}`
+    throw new RallyError(
+      `Failed to remove worktree at ${absoluteWorktreePath}: ${error.message}`, EXIT_GENERAL
     );
   }
 }
@@ -147,8 +148,8 @@ export function listWorktrees(repoPath) {
 
     return worktrees;
   } catch (error) {
-    throw new Error(
-      `Failed to list worktrees for ${absoluteRepoPath}: ${error.message}`
+    throw new RallyError(
+      `Failed to list worktrees for ${absoluteRepoPath}: ${error.message}`, EXIT_GENERAL
     );
   }
 }


### PR DESCRIPTION
Converts all user-facing `throw new Error()` in lib/ files to `throw new RallyError()` with appropriate exit codes (`EXIT_CONFIG` for config/setup errors, `EXIT_GENERAL` for validation/dispatch errors).

**Changes across 8 files (53 throw statements):**
- `lib/config.js` — 10 errors → `RallyError` with `EXIT_CONFIG`
- `lib/active.js` — 9 errors → `RallyError` with `EXIT_GENERAL`
- `lib/dispatch-core.js` — 6 errors → `RallyError` with `EXIT_GENERAL`
- `lib/dispatch-issue.js` — 2 errors → `RallyError` with `EXIT_GENERAL`
- `lib/dispatch-pr.js` — 7 errors → `RallyError` with `EXIT_GENERAL`
- `lib/onboard.js` — 10 errors → `RallyError` with `EXIT_CONFIG`
- `lib/worktree.js` — 4 errors → `RallyError` with `EXIT_GENERAL`
- `lib/picker.js` — 5 errors → `RallyError` with `EXIT_GENERAL`

No error messages were changed. Internal/unexpected errors (copilot.js, dispatch-context.js, etc.) remain as plain `Error`.

All 786 tests pass.

Closes #348