### PR TITLE
feat: add --disallow-temp-dir flag for Copilot path isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,16 @@ Before dispatching, Rally checks whether the issue/PR was authored by someone ot
 
 Each dispatch gets its own **git worktree** — an independent working directory with its own branch. This prevents cross-contamination between concurrent dispatches and keeps your main working tree untouched.
 
-> **Note:** Without the Docker sandbox, the agent's working directory is set to the worktree but filesystem access is **not** restricted to it. The agent could potentially read files outside the worktree (e.g., `~/.ssh`, `~/rally/config.yaml`). For sensitive environments, use the Docker sandbox which provides true filesystem isolation.
+Copilot CLI's built-in [path permissions](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/configure-copilot-cli#setting-path-permissions) restrict agents to the worktree directory by default (since Rally sets `cwd` to the worktree path). Rally also passes `--disallow-temp-dir` to further tighten isolation by removing temp directory access.
+
+You can disable this in `config.yaml` if agents need temp directory access:
+
+```yaml
+settings:
+  disallow_temp_dir: false
+```
+
+> **Note:** For maximum filesystem isolation, use the Docker sandbox which provides a full container boundary.
 
 ### Docker sandbox
 

--- a/bin/rally.js
+++ b/bin/rally.js
@@ -136,6 +136,7 @@ const dashboard = program
               trust,
               denyToolsCopilot: settings.deny_tools_copilot,
               denyToolsSandbox: settings.deny_tools_sandbox,
+              disallowTempDir: settings.disallow_temp_dir,
             });
             if (!result.aborted) {
               console.log(`Dispatched issue #${pendingDispatch.number}: ${result.issue.title} → ${result.worktreePath}`);
@@ -152,6 +153,7 @@ const dashboard = program
               promptFile,
               denyToolsCopilot: settings.deny_tools_copilot,
               denyToolsSandbox: settings.deny_tools_sandbox,
+              disallowTempDir: settings.disallow_temp_dir,
             });
             if (!result.aborted) {
               console.log(`Dispatched PR #${pendingDispatch.number}: ${result.pr.title} → ${result.worktreePath}`);
@@ -229,6 +231,7 @@ dispatch
         trust,
         denyToolsCopilot: settings.deny_tools_copilot,
         denyToolsSandbox: settings.deny_tools_sandbox,
+        disallowTempDir: settings.disallow_temp_dir,
       });
       if (result.aborted) return;
       console.log(`Dispatched issue #${number}: ${result.issue.title} → ${result.worktreePath}`);
@@ -282,6 +285,7 @@ dispatch
         trust,
         denyToolsCopilot: settings.deny_tools_copilot,
         denyToolsSandbox: settings.deny_tools_sandbox,
+        disallowTempDir: settings.disallow_temp_dir,
       });
       if (result.aborted) return;
       console.log(`Dispatched PR #${number}: ${result.pr.title} → ${result.worktreePath}`);

--- a/lib/config.js
+++ b/lib/config.js
@@ -159,11 +159,12 @@ function validateReviewTemplate(value) {
  * - `require_trust` ('always'|'never'|'ask', default: 'ask') — trust checking behavior
  * - `deny_tools_copilot` (string[], default: DEFAULT_DENY_TOOLS) — tools denied in non-sandbox mode
  * - `deny_tools_sandbox` (string[], default: DEFAULT_DENY_TOOLS) — tools denied in Docker sandbox mode
+ * - `disallow_temp_dir` (boolean, default: true) — pass --disallow-temp-dir to Copilot CLI
  *
  * Note: review_template type and path traversal are validated here.
  * File existence is validated by dispatch functions at call site.
  *
- * @returns {{ docker_sandbox: 'always'|'never'|'ask', review_template: string|null, require_trust: 'always'|'never'|'ask', deny_tools_copilot: string[], deny_tools_sandbox: string[] }}
+ * @returns {{ docker_sandbox: 'always'|'never'|'ask', review_template: string|null, require_trust: 'always'|'never'|'ask', deny_tools_copilot: string[], deny_tools_sandbox: string[], disallow_temp_dir: boolean }}
  * @throws {Error} If docker_sandbox or require_trust has an invalid value, or deny_tools are not arrays
  */
 export function getSettings() {
@@ -182,12 +183,17 @@ export function getSettings() {
   const denyToolsCopilot = validateDenyTools(rawCopilot, 'deny_tools_copilot');
   const denyToolsSandbox = validateDenyTools(rawSandbox, 'deny_tools_sandbox');
   const reviewTemplate = validateReviewTemplate(settings.review_template);
+  const disallowTempDir = settings.disallow_temp_dir !== undefined ? settings.disallow_temp_dir : true;
+  if (typeof disallowTempDir !== 'boolean') {
+    throw new Error(`Invalid disallow_temp_dir value: must be a boolean`);
+  }
   return {
     docker_sandbox: dockerSandbox,
     review_template: reviewTemplate,
     require_trust: requireTrust,
     deny_tools_copilot: denyToolsCopilot,
     deny_tools_sandbox: denyToolsSandbox,
+    disallow_temp_dir: disallowTempDir,
   };
 }
 

--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -163,6 +163,7 @@ export function launchCopilot(worktreePath, prompt, opts = {}) {
     const agentArgs = [
       '--allow-all-tools',
       ...denyArgs,
+      ...(opts.disallowTempDir !== false ? ['--disallow-temp-dir'] : []),
       '-p', fullPrompt,
     ];
 

--- a/lib/dispatch-core.js
+++ b/lib/dispatch-core.js
@@ -97,6 +97,7 @@ export function setupDispatchWorktree(opts) {
     sandbox = false,
     denyToolsCopilot,
     denyToolsSandbox,
+    disallowTempDir,
     _exec = execFileSync,
     _spawn,
   } = opts;
@@ -141,11 +142,11 @@ export function setupDispatchWorktree(opts) {
       }
       // In sandbox mode, surface all spawn errors — user explicitly requested it
       const logPath = join(worktreePath, '.copilot-output.log');
-      copilotResult = launchCopilot(worktreePath, copilotPrompt, { _spawn, logPath, sandbox: true, denyTools: denyToolsSandbox });
+      copilotResult = launchCopilot(worktreePath, copilotPrompt, { _spawn, logPath, sandbox: true, denyTools: denyToolsSandbox, disallowTempDir });
     } else if (checkCopilotAvailable({ _exec })) {
       try {
         const logPath = join(worktreePath, '.copilot-output.log');
-        copilotResult = launchCopilot(worktreePath, copilotPrompt, { _spawn, logPath, denyTools: denyToolsCopilot });
+        copilotResult = launchCopilot(worktreePath, copilotPrompt, { _spawn, logPath, denyTools: denyToolsCopilot, disallowTempDir });
       } catch {
         // Copilot launch failed — continue without it
       }

--- a/lib/dispatch-issue.js
+++ b/lib/dispatch-issue.js
@@ -33,6 +33,7 @@ export async function dispatchIssue(options = {}) {
     trust,
     denyToolsCopilot,
     denyToolsSandbox,
+    disallowTempDir,
     _exec = execFileSync,
     _spawn,
     _confirm,
@@ -113,6 +114,7 @@ export async function dispatchIssue(options = {}) {
     sandbox,
     denyToolsCopilot,
     denyToolsSandbox,
+    disallowTempDir,
   });
 
   if (setupResult.alreadyExists) {

--- a/lib/dispatch-pr.js
+++ b/lib/dispatch-pr.js
@@ -204,6 +204,7 @@ export async function dispatchPr(options = {}) {
     trust,
     denyToolsCopilot,
     denyToolsSandbox,
+    disallowTempDir,
     _exec = execFileSync,
     _spawn,
     _confirm,
@@ -291,6 +292,7 @@ export async function dispatchPr(options = {}) {
     sandbox,
     denyToolsCopilot,
     denyToolsSandbox,
+    disallowTempDir,
   });
 
   if (setupResult.alreadyExists) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rally",
+  "name": "squad-rally",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rally",
+      "name": "squad-rally",
       "version": "0.1.0",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -1389,7 +1389,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -265,6 +265,7 @@ describe('getSettings', () => {
       require_trust: 'ask',
       deny_tools_copilot: DEFAULT_DENY_TOOLS,
       deny_tools_sandbox: DEFAULT_DENY_TOOLS,
+      disallow_temp_dir: true,
     });
   });
 
@@ -278,6 +279,7 @@ describe('getSettings', () => {
       require_trust: 'ask',
       deny_tools_copilot: DEFAULT_DENY_TOOLS,
       deny_tools_sandbox: DEFAULT_DENY_TOOLS,
+      disallow_temp_dir: true,
     });
   });
 
@@ -297,6 +299,7 @@ describe('getSettings', () => {
       require_trust: 'never',
       deny_tools_copilot: DEFAULT_DENY_TOOLS,
       deny_tools_sandbox: DEFAULT_DENY_TOOLS,
+      disallow_temp_dir: true,
     });
   });
 
@@ -455,5 +458,28 @@ describe('getSettings', () => {
       settings: { deny_tools_sandbox: [] }
     }), 'utf8');
     assert.throws(() => getSettings(), /Invalid deny_tools_sandbox: must not be empty/);
+  });
+
+  test('returns disallow_temp_dir true by default', (t) => {
+    withTempRallyHome(t);
+    const settings = getSettings();
+    assert.strictEqual(settings.disallow_temp_dir, true);
+  });
+
+  test('reads disallow_temp_dir false from config', (t) => {
+    const tempDir = withTempRallyHome(t);
+    writeFileSync(join(tempDir, 'config.yaml'), yaml.dump({
+      settings: { disallow_temp_dir: false }
+    }), 'utf8');
+    const settings = getSettings();
+    assert.strictEqual(settings.disallow_temp_dir, false);
+  });
+
+  test('validates disallow_temp_dir must be boolean', (t) => {
+    const tempDir = withTempRallyHome(t);
+    writeFileSync(join(tempDir, 'config.yaml'), yaml.dump({
+      settings: { disallow_temp_dir: 'yes' }
+    }), 'utf8');
+    assert.throws(() => getSettings(), /Invalid disallow_temp_dir value: must be a boolean/);
   });
 });

--- a/test/copilot.test.js
+++ b/test/copilot.test.js
@@ -274,6 +274,42 @@ describe('launchCopilot', () => {
       );
     }
   });
+
+  test('includes --disallow-temp-dir by default', () => {
+    let captured;
+    const mockSpawn = (cmd, args) => {
+      captured = { cmd, args };
+      return { pid: 42, unref() {} };
+    };
+
+    launchCopilot('/path/to/worktree', 'my prompt', { _spawn: mockSpawn });
+
+    assert.ok(captured.args.includes('--disallow-temp-dir'), 'should include --disallow-temp-dir by default');
+  });
+
+  test('omits --disallow-temp-dir when disallowTempDir is false', () => {
+    let captured;
+    const mockSpawn = (cmd, args) => {
+      captured = { cmd, args };
+      return { pid: 42, unref() {} };
+    };
+
+    launchCopilot('/path/to/worktree', 'my prompt', { _spawn: mockSpawn, disallowTempDir: false });
+
+    assert.ok(!captured.args.includes('--disallow-temp-dir'), 'should not include --disallow-temp-dir when disabled');
+  });
+
+  test('includes --disallow-temp-dir when disallowTempDir is true', () => {
+    let captured;
+    const mockSpawn = (cmd, args) => {
+      captured = { cmd, args };
+      return { pid: 42, unref() {} };
+    };
+
+    launchCopilot('/path/to/worktree', 'my prompt', { _spawn: mockSpawn, disallowTempDir: true });
+
+    assert.ok(captured.args.includes('--disallow-temp-dir'), 'should include --disallow-temp-dir when enabled');
+  });
 });
 
 // =====================================================


### PR DESCRIPTION
## Summary

Leverages Copilot CLI's built-in path permissions to tighten dispatch isolation by adding `--disallow-temp-dir` to agent args by default.

### Changes

1. **lib/copilot.js**: Add `--disallow-temp-dir` to `launchCopilot()` agent args when `opts.disallowTempDir !== false` (default: on)
2. **lib/config.js**: Add `disallow_temp_dir` boolean setting (default: `true`) with validation
3. **bin/rally.js**: Pass `disallowTempDir` from settings through all dispatch paths (issue, pr, dashboard)
4. **lib/dispatch-core.js**: Forward `disallowTempDir` to `launchCopilot()` calls
5. **lib/dispatch-issue.js** / **lib/dispatch-pr.js**: Accept and forward `disallowTempDir`
6. **README.md**: Update Security & Safety section — document path permissions, remove outdated warning about unrestricted filesystem access
7. **Tests**: Add tests for default behavior, opt-out (`disallowTempDir: false`), and config validation

### Config

```yaml
settings:
  disallow_temp_dir: false  # set to false if agents need temp dir access
```

Closes #345