### PR TITLE
refactor: standardize on default path import

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -1,5 +1,5 @@
 import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import path from 'node:path';
 import yaml from 'js-yaml';
 import { readActive, atomicWrite, ensureConfigDir, getConfigDir } from './config.js';
 import { isPidAlive } from './utils.js';
@@ -40,7 +40,7 @@ export function terminatePid(pid, _kill = process.kill.bind(process), _readFileS
 }
 
 function readLockInfo(lockDir) {
-  const infoPath = join(lockDir, 'info.json');
+  const infoPath = path.join(lockDir, 'info.json');
   if (!existsSync(infoPath)) return null;
   try {
     const raw = readFileSync(infoPath, 'utf8');
@@ -56,7 +56,7 @@ function readLockInfo(lockDir) {
 }
 
 function writeLockInfo(lockDir) {
-  const infoPath = join(lockDir, 'info.json');
+  const infoPath = path.join(lockDir, 'info.json');
   const info = { pid: process.pid, timestamp: Date.now() };
   writeFileSync(infoPath, JSON.stringify(info), { encoding: 'utf8', mode: 0o600 });
 }
@@ -88,7 +88,7 @@ function isLockStale(info, lockDir) {
  */
 function acquireLock() {
   const configDir = ensureConfigDir();
-  const lockDir = join(configDir, '.active.lock');
+  const lockDir = path.join(configDir, '.active.lock');
   const lockTimeoutMs = parseInt(process.env.RALLY_LOCK_TIMEOUT_MS, 10) || 10000;
   const deadline = Date.now() + lockTimeoutMs;
   let lastAlivePid = null;
@@ -168,7 +168,7 @@ function withLock(fn) {
 export function cleanupLock() {
   try {
     const configDir = getConfigDir();
-    const lockDir = join(configDir, '.active.lock');
+    const lockDir = path.join(configDir, '.active.lock');
     const info = readLockInfo(lockDir);
     if (info && info.pid === process.pid) {
       rmSync(lockDir, { recursive: true, force: true });
@@ -183,7 +183,7 @@ export function cleanupLock() {
  */
 function writeActiveAtomic(data) {
   const configDir = ensureConfigDir();
-  const activePath = join(configDir, 'active.yaml');
+  const activePath = path.join(configDir, 'active.yaml');
   const content = yaml.dump(data);
   atomicWrite(activePath, content);
 }

--- a/lib/copilot.js
+++ b/lib/copilot.js
@@ -1,6 +1,6 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { openSync, closeSync, readFileSync, existsSync } from 'node:fs';
-import { isAbsolute } from 'node:path';
+import path from 'node:path';
 
 /** UUID v4 regex pattern for validating Copilot session IDs. */
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -138,7 +138,7 @@ export function launchCopilot(worktreePath, prompt, opts = {}) {
   const logPath = opts.logPath || null;
 
   // Validate worktree path before passing to Docker sandbox or as cwd
-  if (!isAbsolute(worktreePath)) {
+  if (!path.isAbsolute(worktreePath)) {
     throw new Error(`worktreePath must be an absolute path, got: "${worktreePath}"`);
   }
   // Defense-in-depth: reject ".." segments that could escape the intended directory
@@ -272,7 +272,7 @@ export function parseSessionIdFromLog(logPath, opts = {}) {
  * @returns {{ status: number|null }}
  */
 export function resumeCopilot(worktreePath, sessionId, opts = {}) {
-  if (!isAbsolute(worktreePath)) {
+  if (!path.isAbsolute(worktreePath)) {
     throw new Error(`worktreePath must be an absolute path, got: "${worktreePath}"`);
   }
   if (/(^|[\\/])\.\.($|[\\/])/.test(worktreePath)) {


### PR DESCRIPTION
Convert destructured path imports to `import path from 'node:path'` for consistency. Default import is more common in this codebase and `path.join()` is more readable than bare `join()`.

**Changes:**
- `lib/copilot.js`: `import { isAbsolute } from 'node:path'` → `import path from 'node:path'`
- `lib/active.js`: `import { join } from 'node:path'` → `import path from 'node:path'`
- Updated all bare `isAbsolute()` and `join()` calls to `path.isAbsolute()` and `path.join()`

All 786 tests pass.

Closes #352