### PR TITLE
refactor: standardize DI parameter naming (#350)

### DIFF
--- a/lib/dispatch-clean.js
+++ b/lib/dispatch-clean.js
@@ -27,8 +27,8 @@ import { cleanupDispatch } from './dispatch-cleanup.js';
 export async function dispatchClean(options = {}) {
   const _getActive = options._getActiveDispatches || getActiveDispatches;
   const _remove = options._removeDispatch || removeDispatch;
-  const _readProj = options._readProjects || readProjects;
-  const _confirmFn = options._confirm || confirm;
+  const _readProjects = options._readProjects || readProjects;
+  const _confirm = options._confirm || confirm;
   const _ora = options._ora || ora;
   const _chalk = options._chalk || chalk;
 
@@ -42,7 +42,7 @@ export async function dispatchClean(options = {}) {
   let targets;
   if (options.all) {
     if (!options.yes) {
-      const confirmed = await _confirmFn({
+      const confirmed = await _confirm({
         message: `Clean all ${dispatches.length} dispatch(es)? Worktrees and branches will be removed.`,
         default: false,
       });
@@ -68,7 +68,7 @@ export async function dispatchClean(options = {}) {
     const spinner = _ora({ text: `Cleaning ${dispatch.id}...` }).start();
 
     try {
-      const repoPath = findProjectPath(dispatch.repo, _readProj);
+      const repoPath = findProjectPath(dispatch.repo, _readProjects);
 
       cleanupDispatch(dispatch, repoPath, {
         _terminatePid: options._terminatePid,

--- a/lib/dispatch-remove.js
+++ b/lib/dispatch-remove.js
@@ -24,7 +24,7 @@ import { cleanupDispatch } from './dispatch-cleanup.js';
 export async function dispatchRemove(number, opts = {}) {
   const _getActive = opts._getActiveDispatches || getActiveDispatches;
   const _remove = opts._removeDispatch || removeDispatch;
-  const _readProj = opts._readProjects || readProjects;
+  const _readProjects = opts._readProjects || readProjects;
   const _ora = opts._ora || ora;
   const _chalk = opts._chalk || chalk;
 
@@ -33,7 +33,7 @@ export async function dispatchRemove(number, opts = {}) {
   const spinner = _ora({ text: `Removing dispatch #${number}...` }).start();
 
   try {
-    const repoPath = findProjectPath(dispatch.repo, _readProj);
+    const repoPath = findProjectPath(dispatch.repo, _readProjects);
 
     cleanupDispatch(dispatch, repoPath, {
       _terminatePid: opts._terminatePid,


### PR DESCRIPTION
Closes #350

- Rename `_confirmFn` to `_confirm` in dispatch-clean.js
- Rename `_readProj` to `_readProjects` in dispatch-clean.js and dispatch-remove.js
- Standardize on full names for DI local variables, matching the convention used elsewhere