### PR TITLE
chore: update all dependencies (#341)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "squad-rally",
       "version": "0.1.0",
       "dependencies": {
-        "@inquirer/prompts": "^7.0.0",
+        "@inquirer/prompts": "^8.3.0",
         "chalk": "^5.0.0",
-        "commander": "^12.0.0",
+        "commander": "^14.0.3",
         "ink": "^5.0.0",
         "ink-table": "^3.1.0",
         "js-yaml": "^4.0.0",
-        "ora": "^8.0.0",
+        "ora": "^9.3.0",
         "react": "^18.0.0"
       },
       "bin": {
@@ -457,26 +457,25 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
+      "integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.0.tgz",
+      "integrity": "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g==",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -488,15 +487,15 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.8.tgz",
+      "integrity": "sha512-Di6dgmiZ9xCSUxWUReWTqDtbhXCuG2MQm2xmgSAIruzQzBqNf49b8E07/vbCYY506kDe8BiwJbegXweG8M1klw==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -508,21 +507,20 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.5.tgz",
+      "integrity": "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -534,16 +532,16 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.8.tgz",
+      "integrity": "sha512-sLcpbb9B3XqUEGrj1N66KwhDhEckzZ4nI/W6SvLXyBX8Wic3LDLENlWRvkOGpCPoserabe+MxQkpiMoI8irvyA==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/external-editor": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -555,16 +553,15 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.8.tgz",
+      "integrity": "sha512-QieW3F1prNw3j+hxO7/NKkG1pk3oz7pOB6+5Upwu3OIwADfPX0oZVppsqlL+Vl/uBHHDSOBY0BirLctLnXwGGg==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -576,15 +573,15 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.3.tgz",
+      "integrity": "sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==",
       "dependencies": {
         "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
+        "iconv-lite": "^0.7.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -596,23 +593,23 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
+      "integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.8.tgz",
+      "integrity": "sha512-p0IJslw0AmedLEkOU+yrEX3Aj2RTpQq7ZOf8nc1DIhjzaxRWrrgeuE5Kyh39fVRgtcACaMXx/9WNo8+GjgBOfw==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -624,15 +621,15 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.8.tgz",
+      "integrity": "sha512-uGLiQah9A0F9UIvJBX52m0CnqtLaym0WpT9V4YZrjZ+YRDKZdwwoEPz06N6w8ChE2lrnsdyhY9sL+Y690Kh9gQ==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -644,16 +641,16 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.8.tgz",
+      "integrity": "sha512-zt1sF4lYLdvPqvmvHdmjOzuUUjuCQ897pdUCO8RbXMUDKXJTTyOQgtn23le+jwcb+MpHl3VAFvzIdxRAf6aPlA==",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -665,23 +662,23 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.0.tgz",
+      "integrity": "sha512-JAj66kjdH/F1+B7LCigjARbwstt3SNUOSzMdjpsvwJmzunK88gJeXmcm95L9nw1KynvFVuY4SzXh/3Y0lvtgSg==",
       "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
+        "@inquirer/checkbox": "^5.1.0",
+        "@inquirer/confirm": "^6.0.8",
+        "@inquirer/editor": "^5.0.8",
+        "@inquirer/expand": "^5.0.8",
+        "@inquirer/input": "^5.0.8",
+        "@inquirer/number": "^4.0.8",
+        "@inquirer/password": "^5.0.8",
+        "@inquirer/rawlist": "^5.2.4",
+        "@inquirer/search": "^4.1.4",
+        "@inquirer/select": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -693,16 +690,15 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.4.tgz",
+      "integrity": "sha512-fTuJ5Cq9W286isLxwj6GGyfTjx1Zdk4qppVEPexFuA6yioCCXS4V1zfKroQqw7QdbDPN73xs2DiIAlo55+kBqg==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -714,17 +710,16 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.4.tgz",
+      "integrity": "sha512-9yPTxq7LPmYjrGn3DRuaPuPbmC6u3fiWcsE9ggfLcdgO/ICHYgxq7mEy1yJ39brVvgXhtOtvDVjDh9slJxE4LQ==",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -736,18 +731,17 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.0.tgz",
+      "integrity": "sha512-OyYbKnchS1u+zRe14LpYrN8S0wH1vD0p2yKISvSsJdH2TpI87fh4eZdWnpdbrGauCRWDph3NwxRmM4Pcm/hx1Q==",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.5",
+        "@inquirer/figures": "^2.0.3",
+        "@inquirer/type": "^4.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -759,11 +753,11 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
+      "integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -868,11 +862,11 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
       "engines": {
-        "node": ">=6"
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -927,28 +921,12 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/convert-to-spaces": {
@@ -1027,6 +1005,27 @@
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -1227,26 +1226,15 @@
       }
     },
     "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1283,11 +1271,11 @@
       }
     },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/object-hash": {
@@ -1313,22 +1301,21 @@
       }
     },
     "node_modules/ora": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
       "dependencies": {
-        "chalk": "^5.3.0",
+        "chalk": "^5.6.2",
         "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
+        "cli-spinners": "^3.2.0",
         "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1372,6 +1359,21 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1496,9 +1498,9 @@
       }
     },
     "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
+      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
       "engines": {
         "node": ">=18"
       },
@@ -1561,78 +1563,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -1653,10 +1583,10 @@
         }
       }
     },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "test:all": "npm test && npm run test:e2e"
   },
   "dependencies": {
-    "@inquirer/prompts": "^7.0.0",
+    "@inquirer/prompts": "^8.3.0",
     "chalk": "^5.0.0",
-    "commander": "^12.0.0",
+    "commander": "^14.0.3",
     "ink": "^5.0.0",
     "ink-table": "^3.1.0",
     "js-yaml": "^4.0.0",
-    "ora": "^8.0.0",
+    "ora": "^9.3.0",
     "react": "^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #341

@jsturtevant — Per your request, this is a draft PR for you to review before merging.

**Updated packages:**
- `@inquirer/prompts`: `^7.0.0` → `^8.3.0`
- `commander`: `^12.0.0` → `^14.0.3`
- `ora`: `^8.0.0` → `^9.3.0`
- `chalk`, `ink`, `ink-table`, `js-yaml`, `react`: minor/patch updates within ranges

**Note:** `ink@6`/`react@19` major upgrade was skipped due to peer dependency conflicts with `ink-table`. This can be tackled separately.

All 109 tests pass.